### PR TITLE
fix(workflow): preserve markdown in git tags

### DIFF
--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -58,7 +58,7 @@ Create a changelog snippet in the requested style:
     ```
 3.  **Tag**:
     ```bash
-    git tag -a v<NEW_VERSION> -m "Release v<NEW_VERSION>" -m "<PASTE_CHANGELOG_HERE>"
+    git -c core.commentChar=";" tag -a v<NEW_VERSION> -m "Release v<NEW_VERSION>" -m "<PASTE_CHANGELOG_HERE>"
     ```
 4.  **Push**:
     ```bash


### PR DESCRIPTION
Updates  to use `git -c core.commentChar=