### PR TITLE
feat: add analytics mock data support with Vitocal250A fixture

### DIFF
--- a/src/vi_api_client/fixtures/Vitocal250A_analytics.json
+++ b/src/vi_api_client/fixtures/Vitocal250A_analytics.json
@@ -1,0 +1,33 @@
+{
+    "data": {
+        "gateway_id": "XXXXXXXXX",
+        "device_id": "0",
+        "resolution": "1d",
+        "timeframe": "1d",
+        "summary_properties": {
+            "heating.power.consumption.dhw": "kWh",
+            "heating.power.consumption.heating": "kWh",
+            "heating.power.consumption.total": "kWh"
+        },
+        "timeseries_properties": {
+            "heating.power.consumption.dhw": "kWh",
+            "heating.power.consumption.heating": "kWh",
+            "heating.power.consumption.total": "kWh"
+        },
+        "data": {
+            "summary": {
+                "heating.power.consumption.dhw": 10.2,
+                "heating.power.consumption.heating": 31.6,
+                "heating.power.consumption.total": 41.8
+            },
+            "timeseries": [
+                {
+                    "timestamp": "2026-01-09T00:00:00+01:00",
+                    "heating.power.consumption.dhw": 10.2,
+                    "heating.power.consumption.heating": 31.6,
+                    "heating.power.consumption.total": 41.8
+                }
+            ]
+        }
+    }
+}

--- a/tests/test_mock_analytics.py
+++ b/tests/test_mock_analytics.py
@@ -1,0 +1,78 @@
+"""Tests for MockViClient analytics functionality."""
+
+import pytest
+
+from vi_api_client.mock_client import MockViClient
+
+
+@pytest.mark.asyncio
+async def test_get_consumption_with_analytics_fixture() -> None:
+    """Test get_consumption with Vitocal250A that has analytics fixture."""
+    # Arrange: Initialize mock client with Vitocal250A device name.
+    client = MockViClient(device_name="Vitocal250A")
+    installations = await client.get_installations()
+    gateways = await client.get_gateways()
+    devices = await client.get_devices(installations[0].id, gateways[0].serial)
+    device = devices[0]
+
+    # Act: Fetch consumption data using summary metric.
+    features = await client.get_consumption(device, "2026-01-01", "2026-01-02")
+
+    # Assert: Should return 3 analytics features with expected values.
+    assert len(features) == 3
+    assert all(f.name.startswith("analytics.") for f in features)
+
+    # Check specific values from the fixture
+    dhw_feature = next(
+        f for f in features if f.name == "analytics.heating.power.consumption.dhw"
+    )
+    assert dhw_feature.value == 10.2
+    assert dhw_feature.unit == "kilowattHour"
+
+    heating_feature = next(
+        f for f in features if f.name == "analytics.heating.power.consumption.heating"
+    )
+    assert heating_feature.value == 31.6
+
+    total_feature = next(
+        f for f in features if f.name == "analytics.heating.power.consumption.total"
+    )
+    assert total_feature.value == 41.8
+
+
+@pytest.mark.asyncio
+async def test_get_consumption_without_analytics_fixture() -> None:
+    """Test get_consumption with device that has no analytics fixture."""
+    # Arrange: Initialize mock client with device that has no analytics data.
+    client = MockViClient(device_name="Vitodens200W")
+    installations = await client.get_installations()
+    gateways = await client.get_gateways()
+    devices = await client.get_devices(installations[0].id, gateways[0].serial)
+    device = devices[0]
+
+    # Act: Attempt to fetch consumption data.
+    features = await client.get_consumption(device, "2026-01-01", "2026-01-02")
+
+    # Assert: Should return empty list (no analytics fixture available).
+    assert features == []
+
+
+@pytest.mark.asyncio
+async def test_get_consumption_specific_metric() -> None:
+    """Test get_consumption with specific metric selection."""
+    # Arrange: Initialize mock client with Vitocal250A.
+    client = MockViClient(device_name="Vitocal250A")
+    installations = await client.get_installations()
+    gateways = await client.get_gateways()
+    devices = await client.get_devices(installations[0].id, gateways[0].serial)
+    device = devices[0]
+
+    # Act: Fetch only DHW consumption metric.
+    features = await client.get_consumption(
+        device, "2026-01-01", "2026-01-02", metric="dhw"
+    )
+
+    # Assert: Should return only 1 feature (dhw).
+    assert len(features) == 1
+    assert features[0].name == "analytics.heating.power.consumption.dhw"
+    assert features[0].value == 10.2

--- a/tests/test_mock_data_integrity.py
+++ b/tests/test_mock_data_integrity.py
@@ -20,8 +20,10 @@ MOCK_DATA_DIR = os.path.join(
 
 
 def get_mock_data_files():
-    """Get list of all mock device JSON files."""
-    return glob.glob(os.path.join(MOCK_DATA_DIR, "*.json"))
+    """Get list of all mock device JSON files (excludes analytics fixtures)."""
+    all_files = glob.glob(os.path.join(MOCK_DATA_DIR, "*.json"))
+    # Exclude analytics fixtures as they have a different structure
+    return [f for f in all_files if not f.endswith("_analytics.json")]
 
 
 @pytest.mark.parametrize("file_path", get_mock_data_files(), ids=os.path.basename)


### PR DESCRIPTION
- Created Vitocal250A_analytics.json with real consumption data
- Extended MockViClient with _load_analytics_data() method
- Updated get_consumption() to parse analytics fixtures when available
- Added 3 comprehensive tests for analytics functionality
- Excluded analytics fixtures from mock data integrity test

MockViClient.get_consumption() now returns real data for devices
with analytics fixtures instead of empty list.
