### PR TITLE
feat: add consumption alias features

### DIFF
--- a/src/vi_api_client/parsing.py
+++ b/src/vi_api_client/parsing.py
@@ -23,6 +23,18 @@ COMPLEX_DATA_INDICATORS = {
     "sun",  # Schedule days
 }
 
+CONSUMPTION_ALIAS_FEATURES = {
+    "heating.power.consumption.dhw",
+    "heating.power.consumption.heating",
+    "heating.power.consumption.total",
+}
+
+CONSUMPTION_ALIAS_MAPPING = {
+    "currentDay": "day",
+    "currentMonth": "month",
+    "currentYear": "year",
+}
+
 
 def parse_feature_flat(data: dict[str, Any]) -> list[Feature]:
     """Parse a nested API feature object into a list of flat Feature objects.
@@ -48,7 +60,7 @@ def parse_feature_flat(data: dict[str, Any]) -> list[Feature]:
         # Return as single complex feature
         control = _find_control_for_complex_feature(base_name, commands)
 
-        return [
+        features_out = [
             Feature(
                 name=base_name,
                 value=properties,  # The whole dict
@@ -58,6 +70,15 @@ def parse_feature_flat(data: dict[str, Any]) -> list[Feature]:
                 control=control,
             )
         ]
+        features_out.extend(
+            _build_consumption_alias_features(
+                base_name=base_name,
+                properties=properties,
+                is_enabled=is_enabled,
+                is_ready=is_ready,
+            )
+        )
+        return features_out
 
     # 2. Flattening Logic
     features_out = []
@@ -105,6 +126,51 @@ def parse_feature_flat(data: dict[str, Any]) -> list[Feature]:
                 is_enabled=is_enabled,
                 is_ready=is_ready,
                 control=control,
+            )
+        )
+
+    return features_out
+
+
+def _build_consumption_alias_features(
+    base_name: str,
+    properties: dict[str, Any],
+    is_enabled: bool,
+    is_ready: bool,
+) -> list[Feature]:
+    """Build synthetic current* alias features for selected consumption metrics.
+
+    Args:
+        base_name: The raw API feature name.
+        properties: The raw properties dictionary of the feature.
+        is_enabled: Whether the feature is enabled.
+        is_ready: Whether the feature is ready.
+
+    Returns:
+        List of synthetic alias features.
+    """
+    if base_name not in CONSUMPTION_ALIAS_FEATURES:
+        return []
+
+    features_out: list[Feature] = []
+
+    for alias_name, source_name in CONSUMPTION_ALIAS_MAPPING.items():
+        source_data = properties.get(source_name)
+        if not isinstance(source_data, dict):
+            continue
+
+        values = source_data.get("value")
+        if not isinstance(values, list) or not values:
+            continue
+
+        features_out.append(
+            Feature(
+                name=f"{base_name}.{alias_name}",
+                value=values[0],
+                unit=source_data.get("unit"),
+                is_enabled=is_enabled,
+                is_ready=is_ready,
+                control=None,
             )
         )
 

--- a/tests/fixtures/parsing/consumption_alias_dhw.json
+++ b/tests/fixtures/parsing/consumption_alias_dhw.json
@@ -1,0 +1,33 @@
+{
+  "feature": "heating.power.consumption.dhw",
+  "isEnabled": true,
+  "isReady": true,
+  "properties": {
+    "day": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        2.6,
+        5.8,
+        3.5
+      ]
+    },
+    "month": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        16,
+        89.7,
+        28.1
+      ]
+    },
+    "year": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        875.0999999999999,
+        1536.8
+      ]
+    }
+  }
+}

--- a/tests/fixtures/parsing/consumption_alias_heating.json
+++ b/tests/fixtures/parsing/consumption_alias_heating.json
@@ -1,0 +1,33 @@
+{
+  "feature": "heating.power.consumption.heating",
+  "isEnabled": true,
+  "isReady": true,
+  "properties": {
+    "day": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        4.6,
+        6.8,
+        7
+      ]
+    },
+    "month": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        32.3,
+        32.1,
+        0
+      ]
+    },
+    "year": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        2565.7,
+        3809.6
+      ]
+    }
+  }
+}

--- a/tests/fixtures/parsing/consumption_alias_total.json
+++ b/tests/fixtures/parsing/consumption_alias_total.json
@@ -1,0 +1,33 @@
+{
+  "feature": "heating.power.consumption.total",
+  "isEnabled": true,
+  "isReady": true,
+  "properties": {
+    "day": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        7.199999999999999,
+        12.6,
+        10.5
+      ]
+    },
+    "month": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        48.3,
+        121.80000000000001,
+        28.1
+      ]
+    },
+    "year": {
+      "type": "array",
+      "unit": "kilowattHour",
+      "value": [
+        3440.8,
+        5346.400000000001
+      ]
+    }
+  }
+}

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -78,12 +78,119 @@ def test_feature_do_not_flatten_history(load_fixture_json):
     # Assert: History array should be kept as-is, not flattened.
     assert len(features) == 1
     feature = features[0]
-    # Should NOT be .day, but the base name because it contains complex key directly?
-    # Logic says: if COMPLEX_DATA_INDICATORS in keys, return SINGLE feature with dict properties.
-    # "day" is in COMPLEX_DATA_INDICATORS.
     assert feature.name == "heating.power.consumption"
     assert isinstance(feature.value, dict)
     assert feature.value["day"]["value"] == [1.1, 2.2, 3.3]
+
+
+def test_feature_adds_consumption_aliases_for_heating(load_fixture_json):
+    """Test that heating consumption gets synthetic current* alias features."""
+    # Arrange: Load fixture for heating power consumption with day/month/year arrays.
+    data = load_fixture_json("parsing/consumption_alias_heating.json")
+
+    # Act: Parse the feature using flat architecture parser.
+    features = parse_feature_flat(data)
+
+    # Assert: Original feature and derived current* aliases should be available.
+    assert len(features) == 4
+
+    base_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.heating"
+    )
+    assert isinstance(base_feature.value, dict)
+    assert base_feature.value["day"]["value"][0] == 4.6
+
+    current_day_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.heating.currentDay"
+    )
+    assert current_day_feature.value == 4.6
+    assert current_day_feature.unit == "kilowattHour"
+
+    current_month_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.heating.currentMonth"
+    )
+    assert current_month_feature.value == 32.3
+
+    current_year_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.heating.currentYear"
+    )
+    assert current_year_feature.value == 2565.7
+
+
+def test_feature_adds_consumption_aliases_for_dhw(load_fixture_json):
+    """Test that DHW consumption gets synthetic current* alias features."""
+    # Arrange: Load fixture for DHW power consumption with day/month/year arrays.
+    data = load_fixture_json("parsing/consumption_alias_dhw.json")
+
+    # Act: Parse the feature using flat architecture parser.
+    features = parse_feature_flat(data)
+
+    # Assert: Original feature and derived current* aliases should be available.
+    assert len(features) == 4
+
+    current_day_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.dhw.currentDay"
+    )
+    assert current_day_feature.value == 2.6
+    assert current_day_feature.unit == "kilowattHour"
+
+    current_month_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.dhw.currentMonth"
+    )
+    assert current_month_feature.value == 16
+
+    current_year_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.dhw.currentYear"
+    )
+    assert current_year_feature.value == 875.0999999999999
+
+
+def test_feature_adds_consumption_aliases_for_total(load_fixture_json):
+    """Test that total consumption gets synthetic current* alias features."""
+    # Arrange: Load fixture for total power consumption with day/month/year arrays.
+    data = load_fixture_json("parsing/consumption_alias_total.json")
+
+    # Act: Parse the feature using flat architecture parser.
+    features = parse_feature_flat(data)
+
+    # Assert: Original feature and derived current* aliases should be available.
+    assert len(features) == 4
+
+    current_day_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.total.currentDay"
+    )
+    assert current_day_feature.value == 7.199999999999999
+    assert current_day_feature.unit == "kilowattHour"
+
+    current_month_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.total.currentMonth"
+    )
+    assert current_month_feature.value == 48.3
+
+    current_year_feature = next(
+        feature
+        for feature in features
+        if feature.name == "heating.power.consumption.total.currentYear"
+    )
+    assert current_year_feature.value == 3440.8
 
 
 def test_feature_priority_value_over_status(load_fixture_json):


### PR DESCRIPTION
## Summary
- add synthetic alias features for heating.power.consumption.heating, .dhw, and .total
- keep the original complex consumption features with their array payloads intact
- add parser fixture coverage and tests for currentDay, currentMonth, and currentYear

## Validation
- ruff format .
- ruff check --fix .
- python3 -m pytest