### PR TITLE
[codex] Align Python 3.14 baseline and packaging

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -33,7 +33,6 @@ Strict guidelines for version control and feature development.
    - `python -m pytest -q`
 3. If the change touches packaging metadata, build config, dependency
    management, or CLI entry points, also validate with:
-   - `python -m pip install build`
    - `python -m build`
 4. Commit with a Conventional Commit style message.
 

--- a/.agent/rules/tech-stack.md
+++ b/.agent/rules/tech-stack.md
@@ -5,8 +5,8 @@ trigger: always_on
 # Tech Stack & Patterns
 
 ## 1. Python Version
-- Runtime baseline is Python 3.12+.
-- CI currently validates against Python 3.12.
+- Runtime baseline is Python 3.14+.
+- CI currently validates against Python 3.14.
 - Prefer matching the CI interpreter locally when possible.
 - Keep tooling configuration aligned with the supported runtime baseline.
 

--- a/.agent/workflows/feature-develop.md
+++ b/.agent/workflows/feature-develop.md
@@ -11,7 +11,7 @@ on a dedicated branch.
 > **Agent Rules Compliance**: During development, you MUST strictly follow ALL rules defined in `.agent/rules/`:
 > - `python-style.md` - Code style (f-strings, naming, sorting, logging)
 > - `python-docs.md` - Documentation (Google Style docstrings)
-> - `tech-stack.md` - Technology choices (Python 3.12+, typing, filesystem, async stack)
+> - `tech-stack.md` - Technology choices (Python 3.14+, typing, filesystem, async stack)
 > - `testing.md` - Test structure and mocking strategy
 > - `architecture-context.md` - Library architecture and repository boundaries
 > - `git-workflow.md` - This workflow itself
@@ -67,7 +67,6 @@ When changing packaging metadata, build config, dependency management, or CLI
 entry points, also validate once with:
 
 ```bash
-python -m pip install build
 python -m build
 ```
 
@@ -111,7 +110,7 @@ git commit -m "type: description"
 
 ## Notes
 - **Always** run lint + format-check + tests before committing
-- **Prefer** matching CI's Python 3.12 baseline locally
+- **Prefer** matching CI's Python 3.14 baseline locally
 - **Add a build check** when packaging or release-relevant surfaces changed
 - **Always** ask user before committing
 - Commit frequently with meaningful messages

--- a/.agent/workflows/pr-submit.md
+++ b/.agent/workflows/pr-submit.md
@@ -34,7 +34,6 @@ The agent must first verify:
     If the change touches `pyproject.toml`, build config, dependency management,
     or CLI entry points, validate the package build too.
     ```bash
-    python -m pip install build
     python -m build
     ```
 

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -21,10 +21,9 @@ library package.
     ruff format --check .
     python -m pytest -q
     ```
-4.  **Build Validation**: Install `build` if needed and verify the package can
-    be built.
+4.  **Build Validation**: Verify the package can be built in the prepared dev
+    environment.
     ```bash
-    python -m pip install build
     python -m build
     ```
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.14"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -22,8 +22,7 @@ jobs:
     - name: Install
       run: |
         pip install --upgrade pip
-        pip install ruff pytest build
-        if [ -f pyproject.toml ]; then pip install .[dev]; fi
+        pip install .[dev]
     - name: Lint & Format (Ruff)
       run: |
         ruff check .
@@ -41,10 +40,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Build
       run: |
-        pip install build
+        pip install .[dev]
         python -m build
     - name: Fetch Tag Message
       id: tag_message

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ should be updated to reflect it.
 Prefer matching the current CI interpreter locally when possible.
 
 ```bash
-python3.12 -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
 python -m pip install '.[dev]'
@@ -115,17 +115,16 @@ python -m pytest -q
 ```
 
 If a change touches packaging metadata, build config, dependency management, or
-CLI entry points, also install `build` if needed and validate with:
+CLI entry points, validate the package build too:
 
 ```bash
-python -m pip install build
 python -m build
 ```
 
 ## CI and Release Notes
 
 - CI currently runs via `.github/workflows/ci_cd.yml`.
-- The `quality-check` job currently runs on Python 3.12.
+- The `quality-check` job currently runs on Python 3.14.
 - Treat `main` as protected by workflow, even if GitHub does not technically
   enforce it in every environment.
 - Releases are published from `v*` tag runs in GitHub Actions.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michael
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Designed for integration with Home Assistant and other async Python applications
 
 ## Installation
 
-This is currently a local development package. **Requires Python 3.12+**.
+This is currently a local development package. **Requires Python 3.14+**.
 
 ```bash
 # Clone the repository
@@ -26,7 +26,7 @@ git clone https://github.com/ignazhabibi/vi_api_client.git
 cd vi_api_client
 
 # Create virtual env
-python3 -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
 
 # Install in editable mode

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -12,7 +12,7 @@ git clone https://github.com/ignazhabibi/vi_api_client.git
 cd vi_api_client
 
 # Create virtual env
-python3 -m venv .venv
+python3.14 -m venv .venv
 source .venv/bin/activate
 
 # Install in editable mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "ruff",
+    "ruff==0.15.8",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,12 @@ description = "Async Python client for Viessmann Climate Solutions API"
 authors = [
   { name = "Michael", email = "antigravity@example.com" },
 ]
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 dependencies = [
     "aiohttp>=3.8.0",
     "pkce>=1.0.3",
@@ -22,10 +22,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "aioresponses",
+    "build",
     "pytest",
     "pytest-asyncio",
-    "aioresponses",
     "pytest-cov",
+    "ruff",
 ]
 
 [project.scripts]
@@ -33,7 +35,7 @@ vi-client = "vi_api_client.cli:main"
 
 [tool.ruff]
 line-length = 88
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -314,7 +314,7 @@ class ViClient:
         return f"{base}/filter"
 
     def _resolve_command_payload(
-        self, device: Device, ctrl: "FeatureControl", target_value: Any
+        self, device: Device, ctrl: FeatureControl, target_value: Any
     ) -> dict[str, Any]:
         """Resolve all parameters required for a command.
 
@@ -357,7 +357,7 @@ class ViClient:
                 )
         return payload
 
-    def _validate_constraints(self, ctrl: "FeatureControl", value: Any) -> None:
+    def _validate_constraints(self, ctrl: FeatureControl, value: Any) -> None:
         """Validate value against all constraints using type-based dispatch.
 
         Args:
@@ -383,7 +383,7 @@ class ViClient:
             validator(ctrl, value)  # type: ignore
 
     def _validate_numeric_constraints(
-        self, ctrl: "FeatureControl", value: int | float
+        self, ctrl: FeatureControl, value: int | float
     ) -> None:
         """Validate numeric bounds and step."""
         if ctrl.min is not None and value < ctrl.min:
@@ -406,12 +406,12 @@ class ViClient:
                     f"(starting from {base})"
                 )
 
-    def _validate_enum_constraints(self, ctrl: "FeatureControl", value: Any) -> None:
+    def _validate_enum_constraints(self, ctrl: FeatureControl, value: Any) -> None:
         """Validate enum options."""
         if value not in ctrl.options:
             raise ValueError(f"Value {value} is not in allowed options: {ctrl.options}")
 
-    def _validate_string_constraints(self, ctrl: "FeatureControl", value: str) -> None:
+    def _validate_string_constraints(self, ctrl: FeatureControl, value: str) -> None:
         """Validate string length and pattern."""
         if ctrl.min_length is not None and len(value) < ctrl.min_length:
             raise ValueError(

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -84,7 +84,7 @@ class OAuth(AbstractAuth):
         try:
             with self.token_file.open() as file:
                 self._token_info = json.load(file)
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError, json.JSONDecodeError:
             self._token_info = {}  # Allow init as empty if invalid/missing
 
     def _save_tokens(self) -> None:
@@ -93,7 +93,7 @@ class OAuth(AbstractAuth):
         try:
             with self.token_file.open() as file:
                 current_data = json.load(file)
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError, json.JSONDecodeError:
             pass
 
         current_data.update(self._token_info)

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -57,7 +57,7 @@ def load_config(token_file: str) -> dict[str, Any]:
     try:
         with Path(token_file).open() as file:
             return json.load(file)
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError, json.JSONDecodeError:
         return {}
 
 

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -144,7 +144,7 @@ def get_client_config_safe(args: argparse.Namespace) -> tuple[str, str]:
 @asynccontextmanager
 async def setup_client_context(
     args, discover: bool = True
-) -> AsyncGenerator[CLIContext, None]:
+) -> AsyncGenerator[CLIContext]:
     """Creates Session, Auth, Client AND performs Auto-Discovery if needed."""
     client_id, redirect_uri = get_client_config_safe(args)
 

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -206,7 +206,7 @@ class MockViClient(ViClient):
 
     async def _execute_command(
         self,
-        ctrl: "FeatureControl",
+        ctrl: FeatureControl,
         params: dict[str, Any],
     ) -> CommandResponse:
         """Mock execution of a command (Success).

--- a/src/vi_api_client/utils.py
+++ b/src/vi_api_client/utils.py
@@ -1,5 +1,7 @@
 """Utility functions for Viessmann API Client."""
 
+from __future__ import annotations
+
 import json
 import re
 from contextlib import suppress
@@ -71,7 +73,7 @@ def parse_cli_params(params_list: list[str]) -> dict[str, Any]:
     return params
 
 
-def format_feature(feature: "Feature") -> str:
+def format_feature(feature: Feature) -> str:
     """Format a feature's value for display (CLI/Logs).
 
     Args:


### PR DESCRIPTION
## Summary

This PR aligns the repository with a Python 3.14 baseline and centralizes development tooling so CI and local setup install from the same `.[dev]` source.

## What changed

- raise the project and CI baseline from Python 3.12 to Python 3.14
- add missing dev tooling dependencies (`ruff`, `build`) to `pyproject.toml`
- switch GitHub Actions to install `.[dev]` instead of manually installing overlapping tools
- update developer docs and agent workflows to match the new baseline and install flow
- add an MIT `LICENSE` file and switch package metadata to SPDX-style `license = "MIT"`
- make small typing cleanups required by the `py314` Ruff target

## Why

The repo previously split dependency ownership between `pyproject.toml` and the workflow, which makes future automation such as Renovate less reliable. The packaging setup also referenced a `LICENSE` file that did not exist and still used the deprecated license classifier pattern.

## Impact

- local setup and CI now use the same dev dependency source
- packaging metadata is cleaner and the built distributions now include the MIT license file
- the repo is better prepared for automated dependency maintenance

## Validation

- `ruff check .`
- `ruff format --check .`
- `.venv/bin/python -m pytest -q`
- `/tmp/vi_api_client_py314/bin/python -m pytest -q`
- `/tmp/vi_api_client_py314/bin/python -m build`
