### PR TITLE
[codex] Add minimum versions for dev tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "aioresponses",
-    "build",
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
+    "aioresponses>=0.7.8",
+    "build>=1.4",
+    "pytest>=9",
+    "pytest-asyncio>=1.3",
+    "pytest-cov>=7.1",
     "ruff==0.15.8",
 ]
 


### PR DESCRIPTION
## Summary

This PR adds explicit minimum-version constraints for currently unversioned development dependencies in `pyproject.toml`.

## Why

This makes the dev-tooling metadata clearer and prepares the repo for Renovate, because the affected packages now have explicit constraints that can be updated intentionally.

## Changes

- add minimum versions for `pytest`, `pytest-asyncio`, `pytest-cov`, `aioresponses`, and `build`
- keep `ruff` pinned at `0.15.8` because CI formatting depends on that exact formatter version

## Validation

- `/tmp/vi_api_client_py314_refresh/bin/python -m build`