### PR TITLE
[codex] Add initial Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "automerge": false,
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "rangeStrategy": "replace",
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "pytest",
+        "pytest-asyncio",
+        "pytest-cov",
+        "aioresponses",
+        "build",
+        "ruff"
+      ],
+      "groupName": "python dev dependencies"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds an initial `renovate.json` for the repository.

## Strategy

- allow Renovate to open PRs
- do not enable automerge yet
- keep the first rollout intentionally conservative so we can observe the update behavior

## Configuration highlights

- `config:recommended` as the base preset
- `automerge: false`
- PR rate limiting via `prConcurrentLimit` and `prHourlyLimit`
- grouped updates for Python dev dependencies
- grouped updates for GitHub Actions
- `rangeStrategy: "replace"` to work cleanly with the current dependency constraints

## Validation

- `python3 -m json.tool renovate.json`