### PR TITLE
[codex] Align agent guidance with repo governance

### DIFF
--- a/.agent/rules/git-workflow.md
+++ b/.agent/rules/git-workflow.md
@@ -21,7 +21,7 @@ Strict guidelines for version control and feature development.
 ### A. Start Clean
 
 1. `git checkout main`
-2. `git pull`
+2. `git pull --ff-only`
 3. `git checkout -b feature/<descriptive-name>`
 
 ### B. Develop
@@ -47,8 +47,13 @@ Strict guidelines for version control and feature development.
 ### D. Re-Sync
 
 1. `git checkout main`
-2. `git pull`
+2. `git pull --ff-only`
 3. `git branch -d feature/<name>`
+
+If the repository uses squash merges, local branch deletion may still warn that
+the feature branch was "not yet merged to HEAD" even after the PR was merged.
+That warning is usually benign if `main` was refreshed successfully and the PR
+contents are present on `origin/main`.
 
 ## 3. Release Process
 
@@ -71,3 +76,5 @@ message.
 - **Validation**: Run `ruff check .`, `ruff format --check .`, and
   `python -m pytest -q` before proposing a push. Add `python -m build` when the
   change touches packaging or release-related surfaces.
+- **Dependency PRs**: Renovate PRs are part of the normal workflow. Review them
+  like any other PR and do not assume automerge is enabled.

--- a/.agent/workflows/feature-develop.md
+++ b/.agent/workflows/feature-develop.md
@@ -21,7 +21,7 @@ Ensure you're working from the latest `main` branch.
 
 ```bash
 git checkout main
-git pull
+git pull --ff-only
 ```
 
 ## Step 2: Create Feature Branch

--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -11,7 +11,7 @@ library package.
 1.  **Branch Check**: Ensure `main` is fully up-to-date.
     ```bash
     git checkout main
-    git pull
+    git pull --ff-only
     ```
 2.  **Clean State**: `git status` must show no modified files.
 3.  **Local Validation**: Run the same quality gates the repo expects before
@@ -88,7 +88,7 @@ tag body becomes the GitHub Release body in CI.
 6.  **Refresh Local Main**:
     ```bash
     git checkout main
-    git pull
+    git pull --ff-only
     ```
 7.  **Tag the Merged Main Commit**:
     ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,12 @@ python -m build
 
 - CI currently runs via `.github/workflows/ci_cd.yml`.
 - The `quality-check` job currently runs on Python 3.14.
-- Treat `main` as protected by workflow, even if GitHub does not technically
-  enforce it in every environment.
+- `main` is protected on GitHub. Treat the pull-request path as mandatory
+  unless the user explicitly requests an emergency bypass.
+- Renovate is enabled via `renovate.json`. Dependency update PRs are expected
+  repository traffic and should be reviewed normally.
+- The current Renovate policy is PR creation without automerge. Do not assume
+  dependency PRs will merge themselves unless the repository config changes.
 - Releases are published from `v*` tag runs in GitHub Actions.
 - The GitHub Release body is populated from the annotated tag message, so
   release tags must be annotated and should include the changelog body.


### PR DESCRIPTION
## Summary

This PR updates the repository agent guidance to match the current GitHub governance and dependency update setup.

## What changed

- document that `main` is now actually protected on GitHub
- document that Renovate is enabled and currently opens PRs without automerge
- switch local sync guidance from bare `git pull` to `git pull --ff-only`
- add a short note that squash-merge branch deletion warnings can be benign after refreshing `main`

## Why

The repository guidance should reflect real repository behavior so local cleanup, release prep, and dependency update PR handling stay consistent with the current setup.

## Scope

This is guidance-only. No runtime code or packaging behavior changes.
