### PR TITLE
build: constrain CI HTTP test dependencies

### DIFF
--- a/.agent/rules/testing.md
+++ b/.agent/rules/testing.md
@@ -68,6 +68,10 @@ For exception-focused tests, `# Act and assert: ...` is acceptable when splittin
 the steps would be artificial.
 
 ## 4. Data & Mocking
+
+- **Compatible Test Stack:** Install development dependencies with
+  `python -m pip install -c constraints-ci.txt '.[dev]'` so local HTTP-mocking
+  tests use the same `aiohttp` and `aioresponses` versions as CI.
 - **Fixture Loading:** Use shared helpers such as `load_fixture_json` for
   `tests/fixtures/` data.
 - **HTTP-Layer Tests:** Use `aioresponses` to mock external API calls against

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install
       run: |
         pip install --upgrade pip
-        pip install .[dev]
+        pip install -c constraints-ci.txt .[dev]
     - name: Lint & Format (Ruff)
       run: |
         ruff check .
@@ -43,7 +43,7 @@ jobs:
         python-version: "3.14"
     - name: Build
       run: |
-        pip install .[dev]
+        pip install -c constraints-ci.txt .[dev]
         python -m build
     - name: Fetch Tag Message
       id: tag_message

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,11 @@ Prefer matching the current CI interpreter locally when possible.
 python3.14 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install '.[dev]'
+python -m pip install -c constraints-ci.txt '.[dev]'
 ```
+
+`constraints-ci.txt` defines the tested Python 3.14 HTTP client and mock
+combination used by CI. Renovate updates that pair through a dedicated PR.
 
 Primary local quality gates:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ source .venv/bin/activate
 pip install -e .
 ```
 
+## Development and Tests
+
+Install the development dependencies with the CI constraints to reproduce the
+tested HTTP client and mock combination locally:
+
+```bash
+python -m pip install -c constraints-ci.txt '.[dev]'
+ruff check .
+ruff format --check .
+python -m pytest -q
+```
+
 ## Quick Start
 
 ### CLI

--- a/constraints-ci.txt
+++ b/constraints-ci.txt
@@ -1,0 +1,3 @@
+# Keep the aiohttp test-mock stack compatible with Python 3.14.
+aiohttp==3.13.4
+aioresponses==0.7.8

--- a/renovate.json
+++ b/renovate.json
@@ -12,11 +12,20 @@
         "pytest",
         "pytest-asyncio",
         "pytest-cov",
-        "aioresponses",
         "build",
         "ruff"
       ],
       "groupName": "python dev dependencies"
+    },
+    {
+      "matchFileNames": ["constraints-ci.txt"],
+      "matchPackageNames": ["aiohttp", "aioresponses"],
+      "groupName": "CI HTTP test stack"
+    },
+    {
+      "matchFileNames": ["pyproject.toml"],
+      "matchPackageNames": ["aiohttp", "aioresponses"],
+      "enabled": false
     },
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Summary
- pin the Python 3.14 aiohttp and aioresponses test stack for reproducible CI
- make Renovate manage that compatible pair as one dedicated update
- document the matching local development installation

## Validation
- ruff check .
- ruff format --check .
- python -m pytest -q (74 passed)
- python -m build
- repeated the checks in a fresh Python 3.14 environment using the CI constraints