### PR TITLE
fix(mock-client): keep feature writes offline

### DIFF
--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -233,8 +233,7 @@ class ViClient:
         self._validate_constraints(control, target_value)
 
         # 3. Execution
-        response_data = await self.connector.post(control.uri, payload)
-        response = CommandResponse.from_api(response_data)
+        response = await self._execute_command(control, payload)
 
         # 4. Optimistic Device Update
         if response.success:
@@ -307,6 +306,24 @@ class ViClient:
     # ------------------------------------------------------------------
     # Private Helper Methods
     # ------------------------------------------------------------------
+
+    async def _execute_command(
+        self, control: FeatureControl, payload: dict[str, Any]
+    ) -> CommandResponse:
+        """Execute a feature command through the live API connector.
+
+        Subclasses can override this boundary to provide alternative command
+        execution without changing validation or optimistic device updates.
+
+        Args:
+            control: The feature control describing the command endpoint.
+            payload: The resolved command parameters.
+
+        Returns:
+            The parsed command response.
+        """
+        response_data = await self.connector.post(control.uri, payload)
+        return CommandResponse.from_api(response_data)
 
     def _build_devices_url(self, installation_id: str, gateway_serial: str) -> str:
         return (

--- a/tests/integration/test_workflow_mock.py
+++ b/tests/integration/test_workflow_mock.py
@@ -1,5 +1,7 @@
 """Integration tests for the full workflow using Mock Client."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 from vi_api_client import MockViClient
@@ -103,6 +105,35 @@ async def test_mock_workflow_vitocal():
         None,
     )
     assert circuit_mode.is_writable is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mock_set_feature_stays_offline():
+    """Verify mock writes use simulated execution instead of the connector."""
+    # Arrange: Hydrate a mock heat pump and guard against connector POST requests.
+    client = MockViClient("Vitocal250A")
+    client.connector.post = AsyncMock()
+    device = (
+        await client.get_devices(
+            installation_id="99999",
+            gateway_serial="MOCK_GW",
+            include_features=True,
+        )
+    )[0]
+    slope = device.get_feature("heating.circuits.0.heating.curve.slope")
+    assert slope is not None
+
+    # Act: Set the writable slope through the standard high-level client method.
+    response, updated_device = await client.set_feature(device, slope, 0.7)
+
+    # Assert: The command should succeed locally without invoking the connector.
+    updated_slope = updated_device.get_feature(slope.name)
+    client.connector.post.assert_not_awaited()
+    assert response.success is True
+    assert updated_slope is not None
+    assert updated_slope.value == 0.7
+    assert slope.value != updated_slope.value
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- route feature commands through an overridable execution boundary
- use the existing MockViClient command simulator for writes
- add a regression test proving mock writes never call the HTTP connector

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src python -m pytest -q (75 passed)

## Documentation
- checked README.md, docs/, AGENTS.md, .agent/rules/, and .agent/workflows/
- no documentation changes needed because this restores the existing offline MockViClient contract