### PR TITLE
fix(auth): manage optional web sessions

### DIFF
--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -5,8 +5,12 @@ This reference covers authentication strategies and connection management.
 ## Connection Management (`websession`)
 
 All Auth classes accept an optional `websession` argument (an `aiohttp.ClientSession`).
-*   **Provided**: The client uses your session. Efficient for reusing connections in a larger app (e.g. Home Assistant).
-*   **Not Provided**: The client creates its own `ClientSession` internally.
+
+*   **Provided**: The client uses your session but leaves its lifecycle under
+    caller control. This is efficient for reusing connections in a larger app
+    (e.g. Home Assistant).
+*   **Not Provided**: The client creates its own `ClientSession` lazily when the
+    first request is made.
 
 ```python
 import aiohttp
@@ -19,6 +23,23 @@ async def main():
         client = ViClient(auth)
         # requests reuse the `session` pool
 ```
+
+When no session is supplied, use the auth provider as an async context manager
+so its internally created session is closed reliably:
+
+```python
+async def main():
+    async with OAuth(
+        client_id="YOUR_CLIENT_ID",
+        redirect_uri="http://localhost:4200/",
+        token_file="tokens.json",
+    ) as auth:
+        client = ViClient(auth)
+        installations = await client.get_installations()
+```
+
+Alternatively, call `await auth.async_close()` when the provider is no longer
+needed. `async_close()` never closes a session passed through `websession`.
 
 ## Base Class: `AbstractAuth`
 

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -5,7 +5,8 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from types import TracebackType
+from typing import Any, Self
 from urllib.parse import urlencode
 
 import aiohttp
@@ -20,14 +21,45 @@ _LOGGER = logging.getLogger(__name__)
 class AbstractAuth(ABC):
     """Abstract class to make authenticated requests."""
 
-    def __init__(self, websession: aiohttp.ClientSession) -> None:
-        """Initialize the auth."""
+    def __init__(self, websession: aiohttp.ClientSession | None = None) -> None:
+        """Initialize the auth with an optional externally managed session."""
         self.websession = websession
+        self._owns_websession = False
+
+    async def __aenter__(self) -> Self:
+        """Enter the authentication context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Close resources owned by the authentication provider."""
+        await self.async_close()
 
     @abstractmethod
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
         pass
+
+    async def _async_get_websession(self) -> aiohttp.ClientSession:
+        """Return an available session, creating an owned one when needed."""
+        if self.websession is None:
+            self.websession = aiohttp.ClientSession()
+            self._owns_websession = True
+        return self.websession
+
+    async def async_close(self) -> None:
+        """Close the web session only when it was created internally."""
+        if not self._owns_websession or self.websession is None:
+            return
+
+        if not self.websession.closed:
+            await self.websession.close()
+        self.websession = None
+        self._owns_websession = False
 
     async def request(
         self, method: str, url: str, **kwargs: Any
@@ -42,7 +74,8 @@ class AbstractAuth(ABC):
         headers["Authorization"] = f"Bearer {access_token}"
         kwargs["headers"] = headers
 
-        return await self.websession.request(method, url, **kwargs)
+        websession = await self._async_get_websession()
+        return await websession.request(method, url, **kwargs)
 
 
 class OAuth(AbstractAuth):
@@ -58,8 +91,8 @@ class OAuth(AbstractAuth):
     ) -> None:
         """Initialize OAuth.
 
-        If websession is None, one must be created externally or managed.
-        For standalone CLI, we might pass one in.
+        If websession is None, a session is created lazily. Use the auth provider
+        as an async context manager or call `async_close` to release it.
 
         Args:
             client_id: OAuth client ID.
@@ -141,7 +174,8 @@ class OAuth(AbstractAuth):
             "code_verifier": self._pkce_verifier,
         }
 
-        async with self.websession.post(ENDPOINT_TOKEN, data=data) as resp:
+        websession = await self._async_get_websession()
+        async with websession.post(ENDPOINT_TOKEN, data=data) as resp:
             if resp.status != 200:
                 text = await resp.text()
                 raise ViAuthError(f"Failed to fetch token: {text}")
@@ -160,7 +194,8 @@ class OAuth(AbstractAuth):
             "refresh_token": refresh_token,
         }
 
-        async with self.websession.post(ENDPOINT_TOKEN, data=data) as resp:
+        websession = await self._async_get_websession()
+        async with websession.post(ENDPOINT_TOKEN, data=data) as resp:
             if resp.status != 200:
                 text = await resp.text()
                 # If refresh fails, we might need to re-auth, but here we just raise

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,16 @@
 """Tests for vitoclient.auth module."""
 
 import json
+import time
 from unittest.mock import MagicMock
 
 import aiohttp
 import pytest
 from aioresponses import aioresponses
 
+from vi_api_client.api import ViClient
 from vi_api_client.auth import AbstractAuth, OAuth
-from vi_api_client.const import ENDPOINT_TOKEN
+from vi_api_client.const import API_BASE_URL, ENDPOINT_INSTALLATIONS, ENDPOINT_TOKEN
 
 
 def test_abstract_auth_cannot_be_instantiated():
@@ -156,3 +158,60 @@ def test_pkce_verifier_generated_on_auth_url(oauth):
 
     # Assert: Verify the results match expectations.
     assert oauth._pkce_verifier is not None
+
+
+@pytest.mark.asyncio
+async def test_oauth_creates_and_closes_internal_websession(tmp_path):
+    """OAuth should manage a session when the caller does not supply one."""
+    # Arrange: Store a valid token and mock the installations endpoint.
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        json.dumps(
+            {
+                "access_token": "test_access_token",
+                "expires_at": time.time() + 3600,
+            }
+        ),
+        encoding="utf-8",
+    )
+    oauth = OAuth(
+        client_id="test_client_id",
+        redirect_uri="http://localhost:4200/",
+        token_file=token_file,
+    )
+    installations_url = f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}"
+
+    with aioresponses() as mock_responses:
+        mock_responses.get(installations_url, payload={"data": []})
+
+        # Act: Make a client request within the OAuth resource context.
+        async with oauth:
+            installations = await ViClient(oauth).get_installations()
+            internal_websession = oauth.websession
+
+    # Assert: The request should work and the internally owned session should close.
+    assert installations == []
+    assert internal_websession is not None
+    assert internal_websession.closed is True
+    assert oauth.websession is None
+
+
+@pytest.mark.asyncio
+async def test_oauth_keeps_external_websession_open(tmp_path):
+    """OAuth should not close a session supplied by the caller."""
+    # Arrange: Create an external session and an OAuth provider that uses it.
+    token_file = tmp_path / "tokens.json"
+    async with aiohttp.ClientSession() as external_websession:
+        oauth = OAuth(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:4200/",
+            token_file=token_file,
+            websession=external_websession,
+        )
+
+        # Act: Enter and exit the OAuth resource context.
+        async with oauth:
+            pass
+
+        # Assert: OAuth should leave the caller-owned session open.
+        assert external_websession.closed is False


### PR DESCRIPTION
## Summary
- lazily create an aiohttp session when OAuth is used without websession
- close only internally owned sessions through async_close or the async context manager
- preserve caller-owned sessions, including the Home Assistant auth bridge used by vi_climate_devices
- document the session lifecycle

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src python -m pytest -q (77 passed)
- verified the vi_climate_devices HAAuth pattern keeps the Home Assistant session open