### PR TITLE
fix(cli): hydrate command dependencies before writes

### DIFF
--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -8,7 +8,7 @@ import os
 import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -23,7 +23,7 @@ from vi_api_client import (
     ViValidationError,
 )
 
-from .models import CommandResponse, Device
+from .models import CommandResponse, Device, Feature
 from .utils import format_feature, parse_cli_params
 
 # Default file to store tokens and config
@@ -409,14 +409,10 @@ async def cmd_set(args) -> None:
     """
     try:
         async with setup_client_context(args) as ctx:
-            device = _transient_device(ctx)
-            features = await ctx.client.get_features(
-                device, feature_names=[args.feature_name]
-            )
-            if not features:
-                print(f"Error: Feature '{args.feature_name}' not found.")
+            target = await _fetch_target_feature(ctx, args.feature_name)
+            if target is None:
                 return
-            feature = features[0]
+            device, feature = target
 
             if not feature.control:
                 print(f"Error: Feature '{feature.name}' is read-only (no control).")
@@ -474,9 +470,10 @@ async def cmd_exec(args) -> None:
     try:
         async with setup_client_context(args) as ctx:
             # 2. Find Feature
-            feature = await _fetch_target_feature(ctx, args.feature_name)
-            if not feature:
+            target = await _fetch_target_feature(ctx, args.feature_name)
+            if target is None:
                 return
+            device, feature = target
 
             if not feature.control:
                 print(f"Error: Feature '{feature.name}' is read-only (no control).")
@@ -500,8 +497,7 @@ async def cmd_exec(args) -> None:
             if target_val is not None:
                 print(f"Using high-level set_feature(target={target_val})...")
                 result, _updated_device = await ctx.client.set_feature(
-                    # Reconstruct transient device if needed, or use ctx
-                    _transient_device(ctx),
+                    device,
                     feature,
                     target_val,
                 )
@@ -522,14 +518,18 @@ async def cmd_exec(args) -> None:
         _LOGGER.error("Error executing command: %s", e)
 
 
-async def _fetch_target_feature(ctx: CLIContext, name: str) -> Any | None:
-    """Helper to fetch a single feature by name."""
+async def _fetch_target_feature(
+    ctx: CLIContext, name: str
+) -> tuple[Device, Feature] | None:
+    """Fetch a target feature together with its complete device context."""
     device = _transient_device(ctx)
-    features = await ctx.client.get_features(device, feature_names=[name])
-    if not features:
+    features = await ctx.client.get_features(device)
+    hydrated_device = replace(device, features=features)
+    feature = hydrated_device.get_feature(name)
+    if feature is None:
         print(f"Error: Feature '{name}' not found.")
         return None
-    return features[0]
+    return hydrated_device, feature
 
 
 def _transient_device(ctx: CLIContext) -> Device:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -94,6 +94,7 @@ async def test_cmd_set_success(mock_cli_context, capsys):
         mock_cli_context.client.set_feature.assert_called()
         # Verify call args for set_feature: (device, feature, value)
         call_args_set = mock_cli_context.client.set_feature.call_args[0]
+        assert call_args_set[0].get_feature("heating.curve.slope") is mock_feature
         assert call_args_set[2] == 1.4  # Value parsed from float
 
         # Verify output
@@ -165,20 +166,78 @@ async def test_cmd_exec_success(mock_cli_context, capsys):
         assert mock_cli_context.client.get_features.called
         # Check first argument (Device)
         args_list = mock_cli_context.client.get_features.call_args[0]
-        kwargs_list = mock_cli_context.client.get_features.call_args[1]
         # args_list is (device,)
         assert args_list[0].id == "DEV1"
-        assert kwargs_list["feature_names"] == ["heating.curve.slope"]
+        assert mock_cli_context.client.get_features.call_args[1] == {}
 
         # Should call set_feature
         mock_cli_context.client.set_feature.assert_called()
         # Verify call args for set_feature: (device, feature, value)
         call_args_set = mock_cli_context.client.set_feature.call_args[0]
+        assert call_args_set[0].get_feature("heating.curve.slope") is mock_feature
         assert call_args_set[2] == 1.4  # Value parsed from float
 
         # Verify output
         captured = capsys.readouterr()
         assert "Success!" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_set_hydrates_required_command_dependencies(mock_cli_context):
+    """Test CLI writes provide sibling values required by a command."""
+    # Arrange: Provide heating-curve features that share the setCurve command.
+    args = Namespace(
+        feature_name="heating.curve.slope",
+        value="1.4",
+        token_file="tokens.json",
+        client_id=None,
+        redirect_uri=None,
+        insecure=False,
+        mock_device=None,
+        installation_id=None,
+        gateway_serial=None,
+        device_id=None,
+    )
+    control = FeatureControl(
+        command_name="setCurve",
+        param_name="slope",
+        required_params=["shift", "slope"],
+        parent_feature_name="heating.curve",
+        uri="uri",
+    )
+    slope = Feature(
+        name="heating.curve.slope",
+        value=1.0,
+        unit=None,
+        is_enabled=True,
+        is_ready=True,
+        control=control,
+    )
+    shift = Feature(
+        name="heating.curve.shift",
+        value=4.0,
+        unit=None,
+        is_enabled=True,
+        is_ready=True,
+        control=control,
+    )
+    mock_cli_context.client.get_features.return_value = [slope, shift]
+    mock_cli_context.client.set_feature.return_value = (
+        MagicMock(success=True, message=None, reason=None),
+        MagicMock(),
+    )
+
+    with patch("vi_api_client.cli.setup_client_context") as mock_setup:
+        mock_setup.return_value.__aenter__.return_value = mock_cli_context
+
+        # Act: Set the slope through the CLI command.
+        await cmd_set(args)
+
+    # Assert: The write should receive a device containing the sibling shift value.
+    command_device = mock_cli_context.client.set_feature.call_args.args[0]
+    assert command_device.get_feature("heating.curve.slope") is slope
+    assert command_device.get_feature("heating.curve.shift") is shift
+    assert mock_cli_context.client.get_features.call_args.kwargs == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- hydrate CLI write targets with the complete feature list
- retain sibling values required by multi-parameter commands
- cover the setCurve dependency path with a regression test

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src python -m pytest -q (78 passed)
- python -m build