### PR TITLE
fix(cli): persist login client configuration

### DIFF
--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -17,6 +17,9 @@ vi-client login --client-id <YOUR_CLIENT_ID> --redirect-uri <YOUR_REDIRECT_URI>
 # export VIESSMANN_REDIRECT_URI=<YOUR_REDIRECT_URI>
 ```
 Follow the URL, log in, and paste the code back into the terminal.
+The client ID and redirect URI used during login are saved with the tokens, so
+later commands can reuse them without repeating `--client-id`. Environment
+variables and explicit command-line arguments continue to take precedence.
 
 ## 2. List Devices
 View all installations, gateways, and devices available to your account.

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -27,6 +27,7 @@ from .models import CommandResponse, Device
 from .utils import format_feature, parse_cli_params
 
 # Default file to store tokens and config
+DEFAULT_REDIRECT_URI = "http://localhost:4200/"
 TOKEN_FILE = "tokens.json"
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -61,6 +62,21 @@ def load_config(token_file: str) -> dict[str, Any]:
         return {}
 
 
+def _save_client_config(token_file: str, client_id: str, redirect_uri: str) -> None:
+    """Save client configuration alongside the OAuth tokens.
+
+    Args:
+        token_file: Path to the JSON token and configuration file.
+        client_id: OAuth client ID used for authentication.
+        redirect_uri: OAuth redirect URI used for authentication.
+    """
+    config = load_config(token_file)
+    config.update({"client_id": client_id, "redirect_uri": redirect_uri})
+
+    with Path(token_file).open("w", encoding="utf-8") as file:
+        json.dump(config, file, indent=2)
+
+
 async def create_session(args) -> aiohttp.ClientSession:
     """Create aiohttp session with optional insecure SSL.
 
@@ -85,8 +101,7 @@ async def cmd_login(args) -> None:
     Args:
         args: Parsed command line arguments including client_id and redirect_uri.
     """
-    client_id = args.client_id
-    redirect_uri = args.redirect_uri
+    client_id, redirect_uri = get_client_config(args)
 
     auth = OAuth(client_id, redirect_uri, args.token_file)
     url = auth.get_authorization_url()
@@ -99,6 +114,7 @@ async def cmd_login(args) -> None:
         auth.websession = session
         await auth.async_fetch_details_from_code(code)
 
+    _save_client_config(args.token_file, client_id, redirect_uri)
     print(f"Successfully authenticated! Tokens and config saved to {args.token_file}")
 
 
@@ -113,6 +129,7 @@ def get_client_config(args) -> tuple[str, str]:
         args.redirect_uri
         or os.getenv("VIESSMANN_REDIRECT_URI")
         or config.get("redirect_uri")
+        or DEFAULT_REDIRECT_URI
     )
 
     if not client_id:
@@ -655,9 +672,7 @@ async def async_main() -> None:  # noqa: PLR0915
     common_parser.add_argument(
         "--client-id", help="OAuth Client ID (optional if saved)"
     )
-    common_parser.add_argument(
-        "--redirect-uri", default="http://localhost:4200/", help="OAuth Redirect URI"
-    )
+    common_parser.add_argument("--redirect-uri", help="OAuth Redirect URI")
     common_parser.add_argument(
         "--token-file", default=TOKEN_FILE, help="Path to save/load tokens"
     )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -12,6 +12,7 @@ from vi_api_client.cli import (
     cmd_list_features,
     cmd_list_mock_devices,
     cmd_list_writable,
+    cmd_login,
     cmd_set,
 )
 from vi_api_client.exceptions import ViValidationError
@@ -99,6 +100,52 @@ async def test_cmd_set_success(mock_cli_context, capsys):
         # Verify output
         captured = capsys.readouterr()
         assert "Success!" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_login_uses_environment_config_and_persists_it(monkeypatch, tmp_path):
+    """Login should reuse environment credentials and save them for later commands."""
+    # Arrange: Seed a token file and provide client settings through the environment.
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text('{"access_token": "existing-token"}', encoding="utf-8")
+    args = Namespace(
+        client_id=None,
+        insecure=False,
+        redirect_uri=None,
+        token_file=str(token_file),
+    )
+    monkeypatch.setenv("VIESSMANN_CLIENT_ID", "environment-client-id")
+    monkeypatch.setenv("VIESSMANN_REDIRECT_URI", "http://localhost:8123/auth")
+    mock_auth = MagicMock()
+    mock_auth.get_authorization_url.return_value = "https://example.invalid/authorize"
+    mock_auth.async_fetch_details_from_code = AsyncMock()
+
+    with (
+        patch("builtins.input", return_value="authorization-code"),
+        patch("vi_api_client.cli.OAuth", return_value=mock_auth) as mock_oauth,
+        patch(
+            "vi_api_client.cli.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+    ):
+        mock_session = MagicMock()
+        mock_create_session.return_value.__aenter__.return_value = mock_session
+
+        # Act: Complete the CLI login flow without explicit command-line settings.
+        await cmd_login(args)
+
+    # Assert: The resolved configuration should be used and stored with tokens.
+    saved_config = json.loads(token_file.read_text(encoding="utf-8"))
+    mock_oauth.assert_called_once_with(
+        "environment-client-id",
+        "http://localhost:8123/auth",
+        str(token_file),
+    )
+    assert mock_auth.websession is mock_session
+    assert saved_config == {
+        "access_token": "existing-token",
+        "client_id": "environment-client-id",
+        "redirect_uri": "http://localhost:8123/auth",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resolve login credentials using the same CLI, environment, and saved-config precedence as other commands
- persist the resolved client ID and redirect URI alongside OAuth tokens
- restore environment and saved configuration as viable redirect URI sources

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src .venv/bin/python -m pytest -q (78 passed)
- .venv/bin/python -m build

## Documentation
Checked README.md, docs/, AGENTS.md, .agent/rules/, and .agent/workflows/. Updated the CLI login reference to document persisted settings and precedence.