### PR TITLE
fix(mock): exclude analytics fixtures from device list

### DIFF
--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -75,9 +75,11 @@ class MockViClient(ViClient):
         if not fixtures_dir.exists():
             return []
 
-        files = [file.name for file in fixtures_dir.glob("*.json")]
-        # Return sorted names without extension
-        return sorted([Path(file).stem for file in files])
+        return sorted(
+            file.stem
+            for file in fixtures_dir.glob("*.json")
+            if not file.stem.endswith("_analytics")
+        )
 
     def _load_analytics_data(self) -> dict[str, Any] | None:
         """Load optional analytics fixture if available.

--- a/tests/test_mock_data_integrity.py
+++ b/tests/test_mock_data_integrity.py
@@ -10,6 +10,7 @@ import os
 
 import pytest
 
+from vi_api_client.mock_client import MockViClient
 from vi_api_client.parsing import parse_feature_flat
 
 # Path to the bundled fixtures (src/vi_api_client/fixtures)
@@ -24,6 +25,14 @@ def get_mock_data_files():
     all_files = glob.glob(os.path.join(MOCK_DATA_DIR, "*.json"))
     # Exclude analytics fixtures as they have a different structure
     return [f for f in all_files if not f.endswith("_analytics.json")]
+
+
+def test_available_mock_devices_excludes_analytics_fixtures():
+    """Only device fixtures should be offered as selectable mock devices."""
+    devices = MockViClient.get_available_mock_devices()
+
+    assert "Vitocal250A" in devices
+    assert "Vitocal250A_analytics" not in devices
 
 
 @pytest.mark.parametrize("file_path", get_mock_data_files(), ids=os.path.basename)


### PR DESCRIPTION
## Summary
- exclude auxiliary analytics fixtures from selectable mock-device names
- retain analytics fixtures for consumption tests and mock consumption data
- add a regression test for the public mock-device list

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src .venv/bin/python -m pytest -q (78 passed)
- .venv/bin/python -m build

## Documentation
Checked README.md, docs/, AGENTS.md, .agent/rules/, and .agent/workflows/. No update is needed: the documented command already promises selectable mock devices; this fixes the returned list to match that contract.