### PR TITLE
chore(release): bump version to 1.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_api_client"
-version = "1.3.0"
+version = "1.3.1"
 description = "Async Python client for Viessmann Climate Solutions API"
 authors = [
   { name = "Michael", email = "antigravity@example.com" },


### PR DESCRIPTION
## Summary
- bump the package version from 1.3.0 to 1.3.1

## Validation
- ruff check .
- ruff format --check .
- PYTHONPATH=src .venv/bin/python -m pytest -q (86 passed)
- .venv/bin/python -m build

## Documentation
Checked README.md, docs/, AGENTS.md, .agent/rules/tech-stack.md, .agent/rules/git-workflow.md, and .agent/workflows/release.md. No version references outside pyproject.toml require an update.