### PR TITLE
fix(cli): keep mock mode fully offline

### DIFF
--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -103,6 +103,8 @@ vi-client get-consumption --metric summary
 
 ## 9. Mock Devices (Offline Mode)
 The client includes sample data for various devices, allowing you to test integration logic without a real account.
+Mock mode does not read OAuth credentials or `tokens.json` and never makes network
+requests.
 
 ```bash
 # List available mock devices

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger(__name__)
 class CLIContext:
     """Context for CLI commands."""
 
-    session: aiohttp.ClientSession
+    session: aiohttp.ClientSession | None
     client: ViClient | MockViClient
     # Found IDs (either from args or auto-discovery)
     inst_id: str
@@ -144,103 +144,81 @@ def get_client_config(args) -> tuple[str, str]:
     return client_id, redirect_uri
 
 
-def get_client_config_safe(args: argparse.Namespace) -> tuple[str, str]:
-    """Get config but return empty strings if missing (for mock mode).
-
-    Args:
-        args: Parsed command line arguments.
-
-    Returns:
-        Tuple of (client_id, redirect_uri).
-    """
-    # For mock mode, we don't strictly need client_id, so we can be lenient.
-    if args.mock_device:
-        return "mock_id", "mock_uri"
-    return get_client_config(args)
-
-
 @asynccontextmanager
 async def setup_client_context(
     args, discover: bool = True
 ) -> AsyncGenerator[CLIContext]:
     """Creates Session, Auth, Client AND performs Auto-Discovery if needed."""
-    client_id, redirect_uri = get_client_config_safe(args)
+    if args.mock_device:
+        client = MockViClient(args.mock_device)
+        inst_id = getattr(args, "installation_id", None) or "99999"
+        gw_serial = getattr(args, "gateway_serial", None) or "MOCK_GATEWAY"
+        dev_id = getattr(args, "device_id", None) or "0"
+        print(f"Using Mock Device: {args.mock_device}")
+        yield CLIContext(None, client, inst_id, gw_serial, dev_id)
+        return
+
+    client_id, redirect_uri = get_client_config(args)
 
     async with await create_session(args) as session:
         auth = OAuth(client_id, redirect_uri, args.token_file, session)
 
-        # Initialize Client
-        if args.mock_device:
-            client = MockViClient(args.mock_device, auth)
-            # Default mock IDs
-            inst_id = getattr(args, "installation_id", None) or "99999"
-            gw_serial = getattr(args, "gateway_serial", None) or "MOCK_GATEWAY"
-            dev_id = getattr(args, "device_id", None) or "0"
-            print(f"Using Mock Device: {args.mock_device}")
-        else:
-            client = ViClient(auth)
-            inst_id = getattr(args, "installation_id", None)
-            gw_serial = getattr(args, "gateway_serial", None)
-            dev_id = getattr(args, "device_id", None)
+        client = ViClient(auth)
+        inst_id = getattr(args, "installation_id", None)
+        gw_serial = getattr(args, "gateway_serial", None)
+        dev_id = getattr(args, "device_id", None)
 
-            # Perform Auto-Discovery if IDs are missing
-            if discover and not (inst_id and gw_serial and dev_id):
-                gateways = await client.get_gateways()
-                if not gateways:
-                    print("No gateways found.")
-                    raise ValueError("No gateways found.")
+        # Perform Auto-Discovery if IDs are missing.
+        if discover and not (inst_id and gw_serial and dev_id):
+            gateways = await client.get_gateways()
+            if not gateways:
+                print("No gateways found.")
+                raise ValueError("No gateways found.")
 
-                if gw_serial:
-                    gateway = next(
-                        (
-                            gateway
-                            for gateway in gateways
-                            if gateway.serial == gw_serial
-                        ),
-                        None,
+            if gw_serial:
+                gateway = next(
+                    (gateway for gateway in gateways if gateway.serial == gw_serial),
+                    None,
+                )
+                if not gateway:
+                    raise ValueError(f"Gateway '{gw_serial}' not found.")
+                if inst_id and gateway.installation_id != inst_id:
+                    raise ValueError(
+                        f"Gateway '{gw_serial}' does not belong to installation "
+                        f"'{inst_id}'."
                     )
-                    if not gateway:
-                        raise ValueError(f"Gateway '{gw_serial}' not found.")
-                    if inst_id and gateway.installation_id != inst_id:
-                        raise ValueError(
-                            f"Gateway '{gw_serial}' does not belong to installation "
-                            f"'{inst_id}'."
-                        )
-                elif inst_id:
-                    gateway = next(
-                        (
-                            gateway
-                            for gateway in gateways
-                            if gateway.installation_id == inst_id
-                        ),
-                        None,
-                    )
-                    if not gateway:
-                        raise ValueError(
-                            f"No gateway found for installation '{inst_id}'."
-                        )
-                else:
-                    gateway = gateways[0]
+            elif inst_id:
+                gateway = next(
+                    (
+                        gateway
+                        for gateway in gateways
+                        if gateway.installation_id == inst_id
+                    ),
+                    None,
+                )
+                if not gateway:
+                    raise ValueError(f"No gateway found for installation '{inst_id}'.")
+            else:
+                gateway = gateways[0]
 
-                inst_id = gateway.installation_id
-                gw_serial = gateway.serial
+            inst_id = gateway.installation_id
+            gw_serial = gateway.serial
 
-                if not dev_id:
-                    devices = await client.get_devices(inst_id, gw_serial)
-                    if not devices:
-                        raise ValueError("No devices found.")
+            if not dev_id:
+                devices = await client.get_devices(inst_id, gw_serial)
+                if not devices:
+                    raise ValueError("No devices found.")
 
-                    # Prefer Device "0" (Heating System)
-                    # Prefer Device "0" (Heating System)
-                    target_dev = next(
-                        (device for device in devices if device.id == "0"),
-                        devices[0],
-                    )
-                    dev_id = target_dev.id
-                    print(
-                        f"Auto-selected Context: Inst={inst_id}, GW={gw_serial}, "
-                        f"Dev={dev_id}"
-                    )
+                # Prefer device "0" (heating system).
+                target_dev = next(
+                    (device for device in devices if device.id == "0"),
+                    devices[0],
+                )
+                dev_id = target_dev.id
+                print(
+                    f"Auto-selected Context: Inst={inst_id}, GW={gw_serial}, "
+                    f"Dev={dev_id}"
+                )
 
         yield CLIContext(session, client, inst_id, gw_serial, dev_id)
 

--- a/tests/test_cli_context.py
+++ b/tests/test_cli_context.py
@@ -8,27 +8,44 @@ from vi_api_client.models import Device, Gateway
 
 
 @pytest.mark.asyncio
-async def test_cli_context_mock_mode():
-    """Test CLI context in mock mode (no API calls)."""
-    # Arrange: Create mock client, device, and fixture data for test.
+async def test_cli_context_mock_mode_does_not_create_oauth_or_session(tmp_path):
+    """Mock mode should stay offline without credentials or token access."""
+    # Arrange: Point mock mode at malformed tokens and fail if live setup is used.
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text("{invalid", encoding="utf-8")
     args = Namespace(
         mock_device="Vitodens200W",
         client_id=None,
         redirect_uri=None,
-        token_file="tokens.json",
+        token_file=token_file,
         insecure=False,
         installation_id=None,
         gateway_serial=None,
         device_id=None,
     )
 
-    # Act: Execute the function being tested.
-    async with setup_client_context(args) as ctx:
-        # Assert: Verify the results match expectations.
-        assert isinstance(ctx, CLIContext)
-        assert ctx.inst_id == "99999"
-        assert ctx.gw_serial == "MOCK_GATEWAY"
-        assert ctx.dev_id == "0"
+    with (
+        patch("vi_api_client.cli.OAuth") as mock_oauth,
+        patch(
+            "vi_api_client.cli.create_session", new_callable=AsyncMock
+        ) as mock_create_session,
+    ):
+        mock_create_session.side_effect = AssertionError(
+            "Mock mode must not create an HTTP session"
+        )
+
+        # Act: Build a context for the bundled mock device.
+        async with setup_client_context(args) as ctx:
+            # Assert: The mock context should use deterministic offline defaults.
+            assert isinstance(ctx, CLIContext)
+            assert ctx.session is None
+            assert ctx.inst_id == "99999"
+            assert ctx.gw_serial == "MOCK_GATEWAY"
+            assert ctx.dev_id == "0"
+
+    # Assert: No live authentication or HTTP session should be initialized.
+    mock_oauth.assert_not_called()
+    mock_create_session.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- bypass OAuth and HTTP session setup when a mock device is selected
- ensure mock commands do not read credentials or the token file
- document the offline guarantee and cover it with a regression test

## Validation
- ruff check .
- ruff format --check .
- .venv/bin/python -m pytest -q
- .venv/bin/python -m build