### PR TITLE
fix(auth): protect token storage and redact credentials

### DIFF
--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -74,6 +74,10 @@ If `token_file` is provided, the class automatically:
 
 This ensures persistent authentication across restarts.
 
+If the token file contains invalid JSON, `OAuth` leaves it untouched and raises
+`ViAuthError`. Repair or remove that file before authenticating again; this avoids
+silently losing credentials or saved client configuration.
+
 (The `OAuth` class implements the PKCE flow internally).
 
 ## Token Format

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -5,6 +5,7 @@ import logging
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from types import TracebackType
 from typing import Any, Self
 from urllib.parse import urlencode
@@ -109,30 +110,43 @@ class OAuth(AbstractAuth):
         self._token_info: dict[str, Any] = {}
         self._pkce_verifier: str | None = None
 
-        # Load existing tokens if available
+        # Load existing tokens if available.
         self._load_tokens()
 
     def _load_tokens(self) -> None:
         """Load tokens from file."""
+        self._token_info = self._read_token_file()
+
+    def _read_token_file(self) -> dict[str, Any]:
+        """Read token data without silently replacing malformed files."""
         try:
-            with self.token_file.open() as file:
-                self._token_info = json.load(file)
-        except FileNotFoundError, json.JSONDecodeError:
-            self._token_info = {}  # Allow init as empty if invalid/missing
+            with self.token_file.open(encoding="utf-8") as file:
+                return json.load(file)
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError as error:
+            raise ViAuthError(
+                f"Token file '{self.token_file}' contains invalid JSON and was not "
+                "modified. Repair or remove the file before authenticating again."
+            ) from error
 
     def _save_tokens(self) -> None:
         """Save tokens to file, preserving existing content."""
-        current_data = {}
-        try:
-            with self.token_file.open() as file:
-                current_data = json.load(file)
-        except FileNotFoundError, json.JSONDecodeError:
-            pass
-
+        current_data = self._read_token_file()
         current_data.update(self._token_info)
 
-        with self.token_file.open("w") as file:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=self.token_file.parent,
+            prefix=f".{self.token_file.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as file:
             json.dump(current_data, file, indent=2)
+            temporary_file = Path(file.name)
+
+        temporary_file.replace(self.token_file)
 
     def get_authorization_url(self) -> str:
         """Generate authorization URL and PKCE challenge."""

--- a/src/vi_api_client/utils.py
+++ b/src/vi_api_client/utils.py
@@ -142,7 +142,7 @@ def mask_pii(text: str) -> str:
         return text
 
     # Mask Tokens (Bearer eyJ...)
-    text = re.sub(r"Bearer\s+[a-zA-Z0-9\-_.]+", "Bearer ***", text)
+    text = re.sub(r"Bearer\s+[a-zA-Z0-9\-_.]+", "Bearer ***", text, flags=re.IGNORECASE)
 
     # Mask Gateways in URLs or JSON (16 digit serials)
     # Pattern: gateway_serial, serial, or inside URL path

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,6 +11,7 @@ from aioresponses import aioresponses
 from vi_api_client.api import ViClient
 from vi_api_client.auth import AbstractAuth, OAuth
 from vi_api_client.const import API_BASE_URL, ENDPOINT_INSTALLATIONS, ENDPOINT_TOKEN
+from vi_api_client.exceptions import ViAuthError
 
 
 def test_abstract_auth_cannot_be_instantiated():
@@ -79,6 +80,40 @@ def test_has_tokens_with_token(oauth_with_tokens):
     assert oauth_with_tokens._token_info.get("access_token") == "test_access_token"
 
 
+def test_oauth_rejects_malformed_token_file_without_modifying_it(tmp_path):
+    """Malformed token files should remain intact and explain the recovery action."""
+    # Arrange: Store invalid JSON in the configured token file.
+    token_file = tmp_path / "tokens.json"
+    invalid_content = "{invalid"
+    token_file.write_text(invalid_content, encoding="utf-8")
+
+    # Act and assert: Loading the malformed token file should preserve its content.
+    with pytest.raises(ViAuthError, match="Repair or remove the file"):
+        OAuth(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:4200/",
+            token_file=token_file,
+        )
+
+    # Assert: The invalid file should remain available for manual recovery.
+    assert token_file.read_text(encoding="utf-8") == invalid_content
+
+
+def test_save_tokens_rejects_file_that_becomes_malformed(oauth):
+    """Token saves should not overwrite a file corrupted after initialization."""
+    # Arrange: Initialize OAuth, then replace its absent token file with invalid JSON.
+    invalid_content = "{invalid"
+    oauth.token_file.write_text(invalid_content, encoding="utf-8")
+    oauth._token_info = {"access_token": "new-token"}
+
+    # Act and assert: Saving should preserve the malformed file and explain recovery.
+    with pytest.raises(ViAuthError, match="Repair or remove the file"):
+        oauth._save_tokens()
+
+    # Assert: The malformed token file should not be overwritten by the new token.
+    assert oauth.token_file.read_text(encoding="utf-8") == invalid_content
+
+
 @pytest.mark.asyncio
 async def test_async_get_access_token_with_valid_token(oauth_with_tokens):
     """Test getting access token when token is valid."""
@@ -112,6 +147,27 @@ async def test_async_refresh_access_token(oauth_with_tokens, load_fixture_json):
 
         # Assert: Verify the results match expectations.
         assert oauth_with_tokens._token_info["access_token"] == "refreshed_access_token"
+
+
+@pytest.mark.asyncio
+async def test_code_exchange_failure_does_not_write_tokens(oauth):
+    """Rejected authorization codes should not create or alter token storage."""
+    # Arrange: Start an authorization flow and mock a rejected token exchange.
+    oauth.get_authorization_url()
+    with aioresponses() as mock_responses:
+        mock_responses.post(
+            ENDPOINT_TOKEN, status=400, body="invalid authorization code"
+        )
+
+        async with aiohttp.ClientSession() as session:
+            oauth.websession = session
+
+            # Act and assert: A rejected token exchange should raise a library error.
+            with pytest.raises(ViAuthError, match="Failed to fetch token"):
+                await oauth.async_fetch_details_from_code("rejected-code")
+
+    # Assert: Failed authentication should not create a token file.
+    assert not oauth.token_file.exists()
 
 
 def test_token_persistence(tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from vi_api_client.utils import parse_cli_params
+from vi_api_client.utils import mask_pii, parse_cli_params
 
 
 def test_parse_key_value():
@@ -66,3 +66,17 @@ def test_nested_json_value():
     # Assert: Nested JSON should be parsed as Python dict.
     assert isinstance(params["schedule"], dict)
     assert params["schedule"]["day"] == 1
+
+
+@pytest.mark.parametrize("prefix", ["Bearer", "bearer", "BEARER"])
+def test_mask_pii_redacts_bearer_tokens_case_insensitively(prefix):
+    """Bearer token redaction should not depend on header capitalization."""
+    # Arrange: Build an Authorization value with a secret token.
+    token = "sensitive-token-value"
+
+    # Act: Mask the Authorization value.
+    masked_text = mask_pii(f"Authorization: {prefix} {token}")
+
+    # Assert: The token should be absent regardless of the Bearer capitalization.
+    assert token not in masked_text
+    assert masked_text.endswith("Bearer ***")


### PR DESCRIPTION
## Summary
- preserve malformed token files instead of silently replacing them
- write token updates atomically
- redact Bearer tokens regardless of capitalization
- cover rejected code exchanges and malformed token storage

## Validation
- ruff check .
- ruff format --check .
- .venv/bin/python -m pytest -q