### PR TITLE
fix(cli): preserve feature value types

### DIFF
--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -80,6 +80,7 @@ This object abstracts away the complexity of Viessmann Commands. You rarely inte
 | `min` | `float` | Minimum allowed value (numeric). | `0.2` |
 | `max` | `float` | Maximum allowed value (numeric). | `3.5` |
 | `step` | `float` | Step increment (numeric). | `0.1` |
+| `value_type` | `str` | API command value type, e.g. `number`, `boolean`, or `string`. | `'number'` |
 | `options` | `List[str]` | List of valid options (enum). | `['eco', 'comfort']` |
 | `pattern` | `str` | Regex pattern for validation (string). | `'^[a-z]+$'` |
 | `min_length` | `int` | Minimum string length. | `1` |

--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -78,7 +78,9 @@ vi-client set heating.circuits.0.heating.curve.slope 1.4
 # Set operating mode
 vi-client set heating.circuits.0.operating.modes.active heating
 ```
-The CLI automatically handles type conversion (string "1.4" -> float 1.4) and validation against constraints.
+The CLI converts values according to the feature's command type: numeric values
+become numbers, `true`/`false` become booleans, and text values such as `auto`
+or `01` remain strings. It then validates the value against the feature constraints.
 
 ## 7. Advanced: Execute Raw Command
 If you need to execute a command with multiple parameters at once (rare), you can use `exec`.

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import logging
+import math
 import os
 import sys
 from collections.abc import AsyncGenerator
@@ -486,10 +487,7 @@ async def cmd_set(args) -> bool:  # noqa: PLR0911
                 f"Param: {feature.control.param_name})"
             )
 
-            # Simple type conversion
-            target_val = args.value
-            with suppress(ValueError):
-                target_val = float(args.value)
+            target_val = _parse_set_value(args.value, feature)
 
             result, _updated_device = await ctx.client.set_feature(
                 device, feature, target_val
@@ -515,6 +513,78 @@ async def cmd_set(args) -> bool:  # noqa: PLR0911
     except Exception as e:
         _LOGGER.error("Error setting feature: %s", e)
         return False
+
+
+def _parse_set_value(raw_value: str, feature: Feature) -> bool | float | int | str:
+    """Convert a CLI value according to the target command parameter type.
+
+    Args:
+        raw_value: Value provided after the CLI ``set`` command.
+        feature: Writable feature that supplies the command metadata.
+
+    Returns:
+        The value in the type expected by the target command.
+
+    Raises:
+        ViValidationError: If a numeric or boolean command value is malformed.
+    """
+    if feature.control is None:
+        return raw_value
+
+    value_type = feature.control.value_type
+    if value_type is None:
+        value_type = _infer_feature_value_type(feature)
+
+    if value_type == "boolean":
+        normalized_value = raw_value.casefold()
+        if normalized_value == "true":
+            return True
+        if normalized_value == "false":
+            return False
+        raise ViValidationError(
+            f"Value '{raw_value}' for '{feature.name}' must be true or false."
+        )
+
+    if value_type == "integer":
+        try:
+            return int(raw_value)
+        except ValueError as error:
+            raise ViValidationError(
+                f"Value '{raw_value}' for '{feature.name}' must be an integer."
+            ) from error
+
+    if value_type == "number":
+        try:
+            value = float(raw_value)
+        except ValueError as error:
+            raise ViValidationError(
+                f"Value '{raw_value}' for '{feature.name}' must be a number."
+            ) from error
+        if not math.isfinite(value):
+            raise ViValidationError(
+                f"Value '{raw_value}' for '{feature.name}' must be finite."
+            )
+        return value
+
+    return raw_value
+
+
+def _infer_feature_value_type(feature: Feature) -> str:
+    """Infer a legacy feature's command type when API metadata is unavailable."""
+    if isinstance(feature.value, bool):
+        return "boolean"
+    if isinstance(feature.value, int | float):
+        return "number"
+    if feature.control and any(
+        constraint is not None
+        for constraint in (
+            feature.control.min,
+            feature.control.max,
+            feature.control.step,
+        )
+    ):
+        return "number"
+    return "string"
 
 
 async def cmd_exec(args) -> bool:  # noqa: PLR0911

--- a/src/vi_api_client/models.py
+++ b/src/vi_api_client/models.py
@@ -21,6 +21,8 @@ class FeatureControl:
         min: Minimum value (numeric constraint).
         max: Maximum value (numeric constraint).
         step: Step size (numeric constraint).
+        value_type: Viessmann command parameter type, such as ``number`` or
+            ``boolean``.
         options: List of allowed values (enum constraint).
         min_length: Minimum length of string value.
         max_length: Maximum length of string value.
@@ -35,6 +37,7 @@ class FeatureControl:
     min: float | None = None
     max: float | None = None
     step: float | None = None
+    value_type: str | None = None
     options: list[Any] | None = None
     min_length: int | None = None
     max_length: int | None = None

--- a/src/vi_api_client/parsing.py
+++ b/src/vi_api_client/parsing.py
@@ -249,6 +249,7 @@ def _build_control(
         min=_resolve_constraint(["min"], sources),
         max=_resolve_constraint(["max"], sources),
         step=_resolve_constraint(["step", "stepping"], sources),
+        value_type=p_data.get("type"),
         options=_resolve_constraint(["enum"], sources),
         min_length=_resolve_constraint(["minLength"], sources),
         max_length=_resolve_constraint(["maxLength"], sources),
@@ -337,6 +338,7 @@ def _find_control_for_complex_feature(
                     required_params=list(params.keys()),
                     parent_feature_name=base_name,
                     uri=cmd_data.get("uri", ""),
+                    value_type=params[target_param].get("type"),
                     # Complex controls rarely have simple min/max
                 )
     return None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -57,6 +57,7 @@ async def test_cmd_set_success(mock_cli_context, capsys):
         required_params=["slope"],
         parent_feature_name="heating.curve",
         uri="uri",
+        value_type="number",
     )
     mock_feature = Feature(
         name="heating.curve.slope",
@@ -103,6 +104,148 @@ async def test_cmd_set_success(mock_cli_context, capsys):
         # Verify output
         captured = capsys.readouterr()
         assert "Success!" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_set_preserves_string_values(mock_cli_context):
+    """CLI writes should preserve numeric-looking string values."""
+    # Arrange: Create a writable string feature with a numeric-looking enum option.
+    args = Namespace(
+        feature_name="heating.program",
+        value="01",
+        token_file="tokens.json",
+        client_id=None,
+        redirect_uri=None,
+        insecure=False,
+        mock_device=None,
+        installation_id=None,
+        gateway_serial=None,
+        device_id=None,
+    )
+    control = FeatureControl(
+        command_name="setProgram",
+        param_name="program",
+        required_params=["program"],
+        parent_feature_name="heating",
+        uri="uri",
+        value_type="string",
+        options=["01", "auto"],
+    )
+    feature = Feature(
+        name="heating.program",
+        value="auto",
+        unit=None,
+        is_enabled=True,
+        is_ready=True,
+        control=control,
+    )
+    mock_cli_context.client.get_features.return_value = [feature]
+    mock_cli_context.client.set_feature.return_value = (
+        MagicMock(success=True, message=None, reason=None),
+        MagicMock(),
+    )
+
+    with patch("vi_api_client.cli.setup_client_context") as mock_setup:
+        mock_setup.return_value.__aenter__.return_value = mock_cli_context
+
+        # Act: Set the numeric-looking enum value through the CLI.
+        assert await cmd_set(args) is True
+
+    # Assert: The command should receive the exact string rather than a float.
+    assert mock_cli_context.client.set_feature.call_args.args[2] == "01"
+
+
+@pytest.mark.asyncio
+async def test_cmd_set_parses_boolean_values(mock_cli_context):
+    """CLI writes should convert boolean command parameters explicitly."""
+    # Arrange: Create a writable boolean feature and uppercase CLI input.
+    args = Namespace(
+        feature_name="heating.enabled",
+        value="TRUE",
+        token_file="tokens.json",
+        client_id=None,
+        redirect_uri=None,
+        insecure=False,
+        mock_device=None,
+        installation_id=None,
+        gateway_serial=None,
+        device_id=None,
+    )
+    control = FeatureControl(
+        command_name="setEnabled",
+        param_name="enabled",
+        required_params=["enabled"],
+        parent_feature_name="heating",
+        uri="uri",
+        value_type="boolean",
+    )
+    feature = Feature(
+        name="heating.enabled",
+        value=False,
+        unit=None,
+        is_enabled=True,
+        is_ready=True,
+        control=control,
+    )
+    mock_cli_context.client.get_features.return_value = [feature]
+    mock_cli_context.client.set_feature.return_value = (
+        MagicMock(success=True, message=None, reason=None),
+        MagicMock(),
+    )
+
+    with patch("vi_api_client.cli.setup_client_context") as mock_setup:
+        mock_setup.return_value.__aenter__.return_value = mock_cli_context
+
+        # Act: Set the boolean feature through the CLI.
+        assert await cmd_set(args) is True
+
+    # Assert: The command should receive a native boolean value.
+    assert mock_cli_context.client.set_feature.call_args.args[2] is True
+
+
+@pytest.mark.asyncio
+async def test_cmd_set_rejects_invalid_numeric_values(mock_cli_context, capsys):
+    """CLI writes should reject non-numeric input for numeric controls."""
+    # Arrange: Create a numeric feature and provide a text value.
+    args = Namespace(
+        feature_name="heating.curve.slope",
+        value="automatic",
+        token_file="tokens.json",
+        client_id=None,
+        redirect_uri=None,
+        insecure=False,
+        mock_device=None,
+        installation_id=None,
+        gateway_serial=None,
+        device_id=None,
+    )
+    control = FeatureControl(
+        command_name="setCurve",
+        param_name="slope",
+        required_params=["slope"],
+        parent_feature_name="heating.curve",
+        uri="uri",
+        value_type="number",
+    )
+    feature = Feature(
+        name="heating.curve.slope",
+        value=1.4,
+        unit=None,
+        is_enabled=True,
+        is_ready=True,
+        control=control,
+    )
+    mock_cli_context.client.get_features.return_value = [feature]
+
+    with patch("vi_api_client.cli.setup_client_context") as mock_setup:
+        mock_setup.return_value.__aenter__.return_value = mock_cli_context
+
+        # Act: Attempt to submit text to a numeric command parameter.
+        assert await cmd_set(args) is False
+
+    # Assert: The CLI should explain the validation failure without sending a write.
+    assert "must be a number" in capsys.readouterr().out
+    mock_cli_context.client.set_feature.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,7 @@ def test_feature_writable():
         min=0,
         max=100,
         step=1,
+        value_type="number",
         options=[1, 2],
     )
 
@@ -49,6 +50,7 @@ def test_feature_writable():
     assert feature.is_writable is True
     assert feature.control.min == 0
     assert feature.control.max == 100
+    assert feature.control.value_type == "number"
     assert feature.control.options == [1, 2]
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -234,6 +234,7 @@ def test_feature_control_association(load_fixture_json):
     assert feature_slope.control is not None
     assert feature_slope.control.command_name == "setCurve"
     assert feature_slope.control.param_name == "slope"
+    assert feature_slope.control.value_type == "number"
     assert "shift" in feature_slope.control.required_params
 
     feature_shift = next(


### PR DESCRIPTION
## Summary
- carry the Viessmann command parameter type in FeatureControl
- convert CLI set values according to command metadata
- preserve string values that look numeric and validate boolean or numeric input before a write
- document the value-type contract and add regression tests

## Validation
- ruff check .
- ruff format --check .
- .venv/bin/python -m pytest -q
- .venv/bin/python -m build