### PR TITLE
chore(release): bump version to 1.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_api_client"
-version = "1.3.1"
+version = "1.3.2"
 description = "Async Python client for Viessmann Climate Solutions API"
 authors = [
   { name = "Michael", email = "antigravity@example.com" },


### PR DESCRIPTION
## Summary
- bump the package version from 1.3.1 to 1.3.2
- prepare the patch release for the merged CLI and authentication fixes

## Validation
- ruff check .
- ruff format --check .
- .venv/bin/python -m pytest -q
- .venv/bin/python -m build