### PR TITLE
fix(auth): preserve authentication provider errors

### DIFF
--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -43,12 +43,17 @@ needed. `async_close()` never closes a session passed through `websession`.
 
 ## Base Class: `AbstractAuth`
 
-The abstract base class for all authentication providers. It handles the core logic of attaching the Bearer token to requests.
+The abstract base class for all authentication providers. It handles the core
+logic of attaching the Bearer token to requests.
 
 ### Methods
 
-#### `get_access_token() -> str`
-Returns a valid access token. If the current token is expired, it automatically triggers a refresh.
+#### `async_get_access_token() -> str`
+
+Returns a valid access token. Custom authentication providers can raise their
+own exceptions from this method; the client preserves those exceptions so the
+calling application can handle provider-specific recovery. Connection failures
+while sending the authenticated API request are exposed as `ViConnectionError`.
 
 ## `OAuth`
 

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -14,7 +14,7 @@ import aiohttp
 import pkce
 
 from .const import DEFAULT_SCOPES, ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
-from .exceptions import ViAuthError
+from .exceptions import ViAuthError, ViConnectionError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,18 +65,24 @@ class AbstractAuth(ABC):
     async def request(
         self, method: str, url: str, **kwargs: Any
     ) -> aiohttp.ClientResponse:
-        """Make an authenticated request."""
-        try:
-            access_token = await self.async_get_access_token()
-        except ViAuthError:
-            raise
+        """Make an authenticated request.
+
+        Exceptions raised by the authentication provider propagate unchanged.
+
+        Raises:
+            ViConnectionError: If the HTTP request cannot be made.
+        """
+        access_token = await self.async_get_access_token()
 
         headers = kwargs.get("headers", {}).copy()
         headers["Authorization"] = f"Bearer {access_token}"
         kwargs["headers"] = headers
 
         websession = await self._async_get_websession()
-        return await websession.request(method, url, **kwargs)
+        try:
+            return await websession.request(method, url, **kwargs)
+        except (TimeoutError, aiohttp.ClientError) as error:
+            raise ViConnectionError(f"Network error: {error}") from error
 
 
 class OAuth(AbstractAuth):

--- a/src/vi_api_client/connection.py
+++ b/src/vi_api_client/connection.py
@@ -7,7 +7,6 @@ from .auth import AbstractAuth
 from .const import API_BASE_URL
 from .exceptions import (
     ViAuthError,
-    ViConnectionError,
     ViError,
     ViNotFoundError,
     ViRateLimitError,
@@ -108,21 +107,13 @@ class ViConnector:
 
         Handles execution and delegates error checking.
         """
-        try:
-            _LOGGER.debug(mask_pii(f"Request: {method} {url}"))
-            async with await self.auth.request(method, url, **kwargs) as response:
-                # Verify response status and raise exceptions if needed.
-                await _raise_for_status(response)
+        _LOGGER.debug(mask_pii(f"Request: {method} {url}"))
+        async with await self.auth.request(method, url, **kwargs) as response:
+            # Verify response status and raise exceptions if needed.
+            await _raise_for_status(response)
 
-                # Return parsed JSON for success.
-                try:
-                    return await response.json()
-                except Exception:
-                    return {}
-
-        except ViError:
-            # Re-raise business logic errors.
-            raise
-        except Exception as e:
-            # Wrap low-level network errors.
-            raise ViConnectionError(f"Network error: {e}") from e
+            # Return parsed JSON for success.
+            try:
+                return await response.json()
+            except Exception:
+                return {}

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,69 @@
+"""Tests for Vi API connection handling."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from vi_api_client.auth import AbstractAuth
+from vi_api_client.connection import ViConnector
+from vi_api_client.exceptions import ViConnectionError
+
+
+class _ExternalOAuthError(aiohttp.ClientResponseError):
+    """Represent an OAuth error owned by an external authentication provider."""
+
+
+class _RaisingAuth(AbstractAuth):
+    """Raise a configured exception while obtaining an access token."""
+
+    def __init__(self, error: Exception) -> None:
+        """Initialize the authentication provider with its token error."""
+        super().__init__()
+        self.error = error
+
+    async def async_get_access_token(self) -> str:
+        """Raise the configured authentication provider error."""
+        raise self.error
+
+
+class _StaticAuth(AbstractAuth):
+    """Return a static access token for transport error tests."""
+
+    async def async_get_access_token(self) -> str:
+        """Return a static access token."""
+        return "access-token"
+
+
+@pytest.mark.asyncio
+async def test_connector_preserves_external_oauth_error() -> None:
+    """External OAuth errors should reach the caller unchanged."""
+    # Arrange: Configure auth to raise a response-shaped external OAuth error.
+    oauth_error = _ExternalOAuthError(
+        request_info=MagicMock(),
+        history=(),
+        status=400,
+        message="Refresh token rejected",
+        headers=MagicMock(),
+    )
+    connector = ViConnector(_RaisingAuth(oauth_error))
+
+    # Act and assert: The connector should preserve the provider-owned exception.
+    with pytest.raises(_ExternalOAuthError) as raised_error:
+        await connector.get("/installations")
+    assert raised_error.value is oauth_error
+
+
+@pytest.mark.asyncio
+async def test_connector_wraps_aiohttp_connection_error() -> None:
+    """Aiohttp connection failures should remain library connection errors."""
+    # Arrange: Configure the HTTP session to fail while opening the connection.
+    connection_error = aiohttp.ClientConnectionError("Network unavailable")
+    websession = MagicMock(spec=aiohttp.ClientSession)
+    websession.request = AsyncMock(side_effect=connection_error)
+    connector = ViConnector(_StaticAuth(websession))
+
+    # Act and assert: The connector should expose the library transport exception.
+    with pytest.raises(ViConnectionError) as raised_error:
+        await connector.get("/installations")
+    assert raised_error.value.__cause__ is connection_error


### PR DESCRIPTION
## Summary

- preserve exceptions raised by external authentication providers so callers can trigger provider-specific recovery
- translate aiohttp connection failures only at the HTTP transport boundary
- add regression coverage for response-shaped OAuth errors and retained connection error mapping
- document the AbstractAuth exception contract

## Validation

- ruff check .
- ruff format --check .
- python -m pytest -q (97 passed)
- python -m build
- verified with Home Assistant OAuth2TokenRequestReauthError from the consumer environment