### PR TITLE
chore(release): bump version to 1.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vi_api_client"
-version = "1.3.2"
+version = "1.3.3"
 description = "Async Python client for Viessmann Climate Solutions API"
 authors = [
   { name = "Michael", email = "antigravity@example.com" },


### PR DESCRIPTION
## Summary

- bump package version from 1.3.2 to 1.3.3
- prepare the patch release containing the authentication provider exception fix from PR #39

## Validation

- ruff check .
- ruff format --check .
- python -m pytest -q (97 passed)
- python -m build