### PR TITLE
feat: add gateway-scoped device refresh with partial results

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# Viessmann API Client
+
+This context defines the language used to describe Viessmann installations and
+their feature data within the client library.
+
+## Language
+
+**Gateway-scoped device refresh**:
+A coordinated refresh of the enabled and ready features of known devices
+belonging to one gateway.
+_Avoid_: Gateway service, gateway feature snapshot
+
+**Gateway device refresh result**:
+The outcome of a gateway-scoped device refresh, separating successfully
+refreshed devices from device-specific failures.
+_Avoid_: Gateway device snapshot, mixed device list
+
+**Bulk feature fetch**:
+The retrieval of device features through a gateway-scoped API operation rather
+than through one request per device.
+_Avoid_: Gateway feature fetch
+
+**Enabled and ready feature**:
+A device feature that is both enabled by the device configuration and ready for
+interaction at the time it is retrieved.
+_Avoid_: Active feature

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Designed for integration with Home Assistant and other async Python applications
 - **OAuth2 Authentication**: Handles token retrieval and automatic renewal.
 - **Auto-Discovery**: Automatically finds installations, gateways, and devices.
 - **Recursive Feature Flattening**: Converts complex nested API responses into a simple, flat list of features (e.g., `heating.circuits.0.heating.curve.shift`).
+- **Gateway-Scoped Refresh**: Refreshes multiple known devices with one normal-case request while preserving partial successes.
 - **Command Execution**: Supports writing values with automatic parameter resolution (e.g. `setCurve`).
 - **Mock Client**: Includes a robust `MockViClient` for offline development and testing.
 
@@ -87,11 +88,14 @@ async def main():
         installations = await client.get_installations()
         gateways = await client.get_gateways()
 
-        # 2. Get Devices (using first gateway and installation) with Features
-        devices = await client.get_devices(
-            installations[0].id, gateways[0].serial, include_features=True
-        )
-        device = devices[0]  # Usually the heating system (ID: 0)
+        # 2. Discover and refresh devices behind one gateway
+        devices = await client.get_devices(installations[0].id, gateways[0].serial)
+        refresh = await client.update_gateway_devices(devices)
+        for device_id, error in refresh.errors_by_device_id.items():
+            print(f"Device {device_id} could not be refreshed: {error}")
+        if not refresh.updated_devices:
+            return
+        device = refresh.updated_devices[0]
         print(f"Device: {device.model_id} ({device.status})")
 
         # 3. Iterate Features (Flat List)

--- a/docs/02_api_structure.md
+++ b/docs/02_api_structure.md
@@ -110,11 +110,27 @@ if response.success:
 
 The library handles the "magic" of mapping your simple `1.6` value back to the complex JSON structure required by the API.
 
+## 6. Gateway-Scoped Device Refresh
+
+When several known devices belong to the same installation and gateway,
+`update_gateway_devices(devices)` refreshes their enabled and ready features
+with one gateway-scoped bulk feature fetch in the normal case. Returned feature
+URIs are matched to complete, URL-decoded device-ID path segments. Gateway-owned
+features and features for devices outside the requested set are not added to a
+device.
+
+The operation returns successful devices separately from device-specific
+errors. A missing device is retried through its existing per-device endpoint;
+global failures still abort the operation. Existing discovery and single-device
+methods keep their established behavior. The client remains cache-free, so the
+consumer owns polling cadence and stale-state policy.
+
 ## Summary
 
 *   **Everything is a Feature**: No more "Properties" vs "Features".
 *   **Flat Names**: Use full names like `heating.circuits.0.heating.curve.slope`.
 *   **Simple Set**: Use `set_feature(device, feature, value)`.
+*   **Explicit Multi-Device Refresh**: Use `update_gateway_devices` for known devices behind one gateway.
 
 ## Next Steps
 

--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -104,6 +104,18 @@ if response.success:
     pass
 ```
 
+## GatewayDeviceRefreshResult
+
+Frozen result dataclass returned by `update_gateway_devices`. Its attributes
+cannot be reassigned; callers should also treat the contained list and mapping
+as result values rather than mutate them.
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| `updated_devices` | `List[Device]` | New device instances that refreshed successfully, in their relative input order. |
+| `errors_by_device_id` | `Dict[str, ViError]` | Recognized device-specific failures keyed by device ID. Failed original devices are not included in `updated_devices`. |
+| `is_complete` | `bool` | `True` when no device-specific failures occurred. |
+
 ## Next Steps
 
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.

--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -68,6 +68,35 @@ Refreshes a specific device by refetching all its features.
 *   **Returns**: A new `Device` instance with updated features.
 *   **Best for**: Efficient polling. Use this instead of re-discovering the entire installation hierarchy if you already have a `Device` object.
 
+### `update_gateway_devices(devices: List[Device]) -> GatewayDeviceRefreshResult`
+
+Refreshes known devices belonging to one installation and gateway. The normal
+path uses one POST feature-filter request and retrieves enabled and ready
+features only.
+
+*   **Parameters**:
+    *   `devices`: Existing devices from exactly one installation and gateway. Device IDs must be unique.
+*   **Returns**: A `GatewayDeviceRefreshResult`. Successful new devices preserve their relative input order; recognized device-specific failures are keyed separately by device ID.
+*   **Fallback**: Devices omitted from a valid bulk response are retried individually. A gateway-wide `DEVICE_COMMUNICATION_ERROR` retries all requested devices individually.
+*   **Raises**:
+    *   `ValueError` for mixed installations, mixed gateways, or duplicate device IDs.
+    *   `ViResponseError` for malformed successful responses.
+    *   The applicable `ViError` subclass for global authentication, rate-limit, connection, server, or unknown API failures.
+*   **Boundary behavior**: Empty input returns an empty complete result without I/O. Failed original devices are not returned in `updated_devices`.
+
+```python
+result = await client.update_gateway_devices(devices)
+for device in result.updated_devices:
+    use_current_state(device)
+
+for device_id, error in result.errors_by_device_id.items():
+    handle_unavailable_device(device_id, error.error_type)
+```
+
+This method is explicit: `get_features`, `update_device`, `get_devices`, and
+`get_full_installation_status` continue to use their existing request and error
+semantics.
+
 ### `set_feature(device: Device, feature: Feature, target_value: Any) -> tuple[CommandResponse, Device]`
 Sets a new value for a writable feature and returns an optimistically updated device.
 

--- a/docs/07_exceptions_reference.md
+++ b/docs/07_exceptions_reference.md
@@ -11,12 +11,15 @@ All exceptions inherit from `ViError` (and `Exception`).
     *   `ViAuthError`: Authentication failed (401/403). check your tokens.
     *   `ViNotFoundError`: Resource not found (404). Typically happens if you request a feature that does not exist on the device.
     *   `ViRateLimitError`: API Rate Limit exceeded (429). You should back off.
+    *   `ViResponseError`: A successful HTTP response violates the expected response contract.
     *   `ViValidationError`: Bad Request (400) or Validation Error (422). Includes detailed validation messages from the API.
     *   `ViServerInternalError`: Server issues (500+).
 
 ## Exception Details
 
-Exceptions often carry detailed information from the API:
+Exceptions expose an optional `error_id` and an optional `error_type` from
+structured Viessmann error responses. `ViValidationError` additionally exposes
+`validation_errors`.
 
 ```python
 try:
@@ -25,12 +28,19 @@ try:
         # Use updated device
         pass
 except ViValidationError as e:
-    print(f"Validation Failed: {e.message}")
+    print(f"Validation Failed: {e}")
     print(f"Error ID: {e.error_id}")
+    print(f"Error type: {e.error_type}")
     # Specific validation details (list of dicts)
     for err in e.validation_errors:
         print(f" - {err['message']} @ {err['path']}")
 ```
+
+`update_gateway_devices` uses `error_type` to keep
+`DEVICE_COMMUNICATION_ERROR`, `DEVICE_NOT_FOUND`, and
+`PACKAGE_NOT_PAID_FOR` failures from concrete per-device fallbacks in its
+partial result. Authentication, rate-limit, connection, server, unknown API,
+and response-contract errors abort the whole refresh.
 
 ## Handling Specific Cases
 

--- a/docs/adr/0001-use-gateway-scoped-device-refresh.md
+++ b/docs/adr/0001-use-gateway-scoped-device-refresh.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+---
+
+# Use an explicit gateway-scoped device refresh with partial results
+
+`vi_api_client` will expose `update_gateway_devices(devices)` for refreshing the
+enabled and ready features of known devices through the gateway-scoped bulk
+endpoint. The method accepts devices from exactly one installation and gateway
+because the bulk response does not provide enough metadata to reconstruct a
+`Device`, and it returns a `GatewayDeviceRefreshResult` that separates updated
+devices from device-specific errors so that one device cannot fail the whole
+batch.
+
+The existing list-returning discovery and refresh methods retain their current
+behavior. The new operation uses the API's POST filter form, performs targeted
+per-device fallback for missing devices and device-specific communication
+errors, exposes Viessmann's `errorType` on library exceptions, and does not add
+a library cache; consumers remain responsible for retaining stale state and
+interpreting partial availability.

--- a/src/vi_api_client/__init__.py
+++ b/src/vi_api_client/__init__.py
@@ -8,17 +8,19 @@ from .exceptions import (
     ViError,
     ViNotFoundError,
     ViRateLimitError,
+    ViResponseError,
     ViServerInternalError,
     ViValidationError,
 )
 from .mock_client import MockViClient
-from .models import Device, Feature
+from .models import Device, Feature, GatewayDeviceRefreshResult
 from .utils import mask_pii
 
 __all__ = [
     "AbstractAuth",
     "Device",
     "Feature",
+    "GatewayDeviceRefreshResult",
     "MockViClient",
     "OAuth",
     "ViAuthError",
@@ -27,6 +29,7 @@ __all__ = [
     "ViError",
     "ViNotFoundError",
     "ViRateLimitError",
+    "ViResponseError",
     "ViServerInternalError",
     "ViValidationError",
     "mask_pii",

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -6,6 +6,7 @@ import warnings
 from dataclasses import replace
 from datetime import datetime
 from typing import Any
+from urllib.parse import unquote, urlsplit
 
 from .analytics import parse_consumption_response, resolve_properties
 from .auth import AbstractAuth
@@ -16,12 +17,14 @@ from .const import (
     ENDPOINT_GATEWAYS,
     ENDPOINT_INSTALLATIONS,
 )
+from .exceptions import ViError, ViResponseError, ViValidationError
 from .models import (
     CommandResponse,
     Device,
     Feature,
     FeatureControl,
     Gateway,
+    GatewayDeviceRefreshResult,
     Installation,
 )
 from .parsing import parse_feature_flat
@@ -197,6 +200,74 @@ class ViClient:
         features = await self.get_features(device, only_enabled=only_enabled)
         return replace(device, features=features)
 
+    async def update_gateway_devices(
+        self, devices: list[Device]
+    ) -> GatewayDeviceRefreshResult:
+        """Refresh enabled and ready features for devices on one gateway.
+
+        Args:
+            devices: Existing devices belonging to one installation and gateway.
+
+        Returns:
+            The successfully refreshed devices and any device-specific failures.
+
+        Raises:
+            ValueError: If devices span multiple scopes or contain duplicate IDs.
+            ViResponseError: If a successful response violates the API contract.
+            ViError: If a global API or connection failure aborts the refresh.
+        """
+        if not devices:
+            return GatewayDeviceRefreshResult([], {})
+
+        self._validate_gateway_devices(devices)
+
+        first_device = devices[0]
+        url = (
+            f"{ENDPOINT_FEATURES}/{first_device.installation_id}/gateways/"
+            f"{first_device.gateway_serial}/features/filter"
+        )
+        payload = {
+            "includeDevicesFeatures": True,
+            "skipDisabled": True,
+            "skipNotReady": True,
+        }
+        try:
+            response = await self.connector.post(url, payload)
+        except ViValidationError as error:
+            if error.error_type == "DEVICE_COMMUNICATION_ERROR":
+                return await self._refresh_devices_individually(devices)
+            raise
+
+        requested_device_ids = {device.id for device in devices}
+        raw_features_by_device_id, seen_device_ids = self._group_gateway_features(
+            response, requested_device_ids
+        )
+
+        updated_devices_by_id: dict[str, Device] = {}
+        for device in devices:
+            if device.id not in seen_device_ids:
+                continue
+            raw_features = raw_features_by_device_id[device.id]
+            features = self._parse_gateway_device_features(device.id, raw_features)
+            updated_devices_by_id[device.id] = replace(device, features=features)
+
+        missing_devices = [
+            device for device in devices if device.id not in seen_device_ids
+        ]
+        fallback_result = await self._refresh_devices_individually(missing_devices)
+        updated_devices_by_id.update(
+            {device.id: device for device in fallback_result.updated_devices}
+        )
+        updated_devices = [
+            updated_devices_by_id[device.id]
+            for device in devices
+            if device.id in updated_devices_by_id
+        ]
+
+        return GatewayDeviceRefreshResult(
+            updated_devices, fallback_result.errors_by_device_id
+        )
+
     async def set_feature(
         self, device: Device, feature: Feature, target_value: Any
     ) -> tuple[CommandResponse, Device]:
@@ -344,6 +415,132 @@ class ViClient:
         if feature_name:
             return f"{base}/{feature_name}"
         return f"{base}/filter"
+
+    @staticmethod
+    def _validate_gateway_devices(devices: list[Device]) -> None:
+        """Validate that devices form one unambiguous gateway-scoped request."""
+        installation_ids = {device.installation_id for device in devices}
+        gateway_serials = {device.gateway_serial for device in devices}
+        device_ids = [device.id for device in devices]
+        if len(installation_ids) != 1 or len(gateway_serials) != 1:
+            raise ValueError("Devices must belong to the same installation and gateway")
+        if len(set(device_ids)) != len(device_ids):
+            raise ValueError("Devices must have unique IDs")
+
+    def _group_gateway_features(
+        self, response: object, requested_device_ids: set[str]
+    ) -> tuple[dict[str, list[dict[str, Any]]], set[str]]:
+        """Validate and group a gateway response by requested device ID."""
+        if not isinstance(response, dict):
+            raise ViResponseError("Gateway feature response must be an object")
+        raw_response_features = response.get("data")
+        if not isinstance(raw_response_features, list):
+            raise ViResponseError("Gateway feature response data must be a list")
+
+        grouped_features: dict[str, list[dict[str, Any]]] = {
+            device_id: [] for device_id in requested_device_ids
+        }
+        seen_device_ids: set[str] = set()
+        for raw_feature in raw_response_features:
+            if not isinstance(raw_feature, dict):
+                raise ViResponseError("Gateway feature entries must be objects")
+            device_id = self._get_feature_device_id(raw_feature.get("uri"))
+            if device_id in grouped_features:
+                self._validate_gateway_feature(raw_feature)
+                grouped_features[device_id].append(raw_feature)
+                seen_device_ids.add(device_id)
+
+        return grouped_features, seen_device_ids
+
+    @staticmethod
+    def _validate_gateway_feature(raw_feature: dict[str, Any]) -> None:
+        """Validate fields required to parse an ordinary device feature."""
+        feature_name = raw_feature.get("feature")
+        properties = raw_feature.get("properties")
+        commands = raw_feature.get("commands", {})
+        if not isinstance(feature_name, str) or not feature_name:
+            raise ViResponseError("Gateway device feature has no valid feature name")
+        if not isinstance(properties, dict) or not isinstance(commands, dict):
+            raise ViResponseError("Gateway device feature has invalid feature data")
+
+    @staticmethod
+    def _parse_gateway_device_features(
+        device_id: str, raw_features: list[dict[str, Any]]
+    ) -> list[Feature]:
+        """Parse one device's features and expose contract failures consistently."""
+        features = []
+        try:
+            for raw_feature in raw_features:
+                features.extend(parse_feature_flat(raw_feature))
+        except (AttributeError, KeyError, TypeError, ValueError) as error:
+            raise ViResponseError(
+                f"Invalid feature data for device {device_id}"
+            ) from error
+        return features
+
+    def _get_feature_device_id(self, uri: object) -> str | None:
+        """Return the decoded device ID from a device feature URI."""
+        if not isinstance(uri, str) or not uri:
+            raise ViResponseError("Gateway feature entry has no valid URI")
+
+        try:
+            raw_path_segments = urlsplit(uri).path.split("/")
+            if any(
+                re.search(r"%(?![0-9A-Fa-f]{2})", segment)
+                for segment in raw_path_segments
+            ):
+                raise ViResponseError(
+                    "Gateway feature entry has an invalid encoded URI"
+                )
+            path_segments = [
+                unquote(segment, errors="strict") for segment in raw_path_segments
+            ]
+        except ValueError as error:
+            raise ViResponseError("Gateway feature entry has an invalid URI") from error
+
+        device_indexes = [
+            index for index, segment in enumerate(path_segments) if segment == "devices"
+        ]
+        if not device_indexes:
+            return None
+        if len(device_indexes) != 1:
+            raise ViResponseError("Gateway feature URI has ambiguous device ownership")
+
+        devices_index = device_indexes[0]
+        if (
+            devices_index + 1 >= len(path_segments)
+            or not path_segments[devices_index + 1]
+        ):
+            raise ViResponseError("Gateway feature URI has no device ID")
+        return path_segments[devices_index + 1]
+
+    async def _refresh_devices_individually(
+        self, devices: list[Device]
+    ) -> GatewayDeviceRefreshResult:
+        """Refresh devices individually and isolate known device failures."""
+        updated_devices = []
+        errors_by_device_id: dict[str, ViError] = {}
+        device_error_types = {
+            "DEVICE_COMMUNICATION_ERROR",
+            "DEVICE_NOT_FOUND",
+            "PACKAGE_NOT_PAID_FOR",
+        }
+
+        for device in devices:
+            try:
+                features = await self.get_features(device, only_enabled=True)
+            except ViError as error:
+                if error.error_type not in device_error_types:
+                    raise
+                errors_by_device_id[device.id] = error
+            except (AttributeError, KeyError, TypeError, ValueError) as error:
+                raise ViResponseError(
+                    f"Invalid feature data for device {device.id}"
+                ) from error
+            else:
+                updated_devices.append(replace(device, features=features))
+
+        return GatewayDeviceRefreshResult(updated_devices, errors_by_device_id)
 
     def _resolve_command_payload(
         self, device: Device, ctrl: FeatureControl, target_value: Any

--- a/src/vi_api_client/connection.py
+++ b/src/vi_api_client/connection.py
@@ -31,13 +31,13 @@ async def _raise_for_status(response) -> None:
     vi_error_id = None
     error_message = f"HTTP {status}"
     validation_details = []
-    error_type = "UNKNOWN"
+    error_type = None
 
     try:
         data = await response.json()
         vi_error_id = data.get("viErrorId")
         error_message = data.get("message", error_message)
-        error_type = data.get("errorType", "")
+        error_type = data.get("errorType")
         if "validationErrors" in data:
             validation_details = data["validationErrors"]
     except Exception:
@@ -54,27 +54,29 @@ async def _raise_for_status(response) -> None:
 
     # Map status codes to specific exceptions.
     if status == 401:
-        raise ViAuthError(f"Unauthorized: {error_message}", vi_error_id)
+        raise ViAuthError(f"Unauthorized: {error_message}", vi_error_id, error_type)
 
     if status == 403:
-        raise ViAuthError(f"Forbidden: {error_message}", vi_error_id)
+        raise ViAuthError(f"Forbidden: {error_message}", vi_error_id, error_type)
 
     if status == 404:
-        raise ViNotFoundError(f"Not Found: {error_message}", vi_error_id)
+        raise ViNotFoundError(f"Not Found: {error_message}", vi_error_id, error_type)
 
     if status == 429:
-        raise ViRateLimitError("Rate Limit Exceeded", vi_error_id)
+        raise ViRateLimitError("Rate Limit Exceeded", vi_error_id, error_type)
 
     if status in (400, 422):
-        raise ViValidationError(error_message, vi_error_id, validation_details)
+        raise ViValidationError(
+            error_message, vi_error_id, validation_details, error_type
+        )
 
     if status >= 500:
         raise ViServerInternalError(
-            f"Server Error {status}: {error_message}", vi_error_id
+            f"Server Error {status}: {error_message}", vi_error_id, error_type
         )
 
     # Generic catch-all for other error codes.
-    raise ViError(f"Unknown Error {status}: {error_message}", vi_error_id)
+    raise ViError(f"Unknown Error {status}: {error_message}", vi_error_id, error_type)
 
 
 class ViConnector:

--- a/src/vi_api_client/exceptions.py
+++ b/src/vi_api_client/exceptions.py
@@ -6,15 +6,22 @@ from typing import Any
 class ViError(Exception):
     """Base class for all Viessmann errors."""
 
-    def __init__(self, message: str, error_id: str | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        error_id: str | None = None,
+        error_type: str | None = None,
+    ) -> None:
         """Initialize the error.
 
         Args:
             message: The error message.
             error_id: Optional unique error identifier from the API.
+            error_type: Optional Viessmann API error classification.
         """
         super().__init__(message)
         self.error_id = error_id
+        self.error_type = error_type
 
 
 class ViConnectionError(ViError):
@@ -41,6 +48,12 @@ class ViRateLimitError(ViError):
     pass
 
 
+class ViResponseError(ViError):
+    """A successful HTTP response that violates the expected API contract."""
+
+    pass
+
+
 class ViValidationError(ViError):
     """400 Bad Request or 422 Validation Error."""
 
@@ -49,6 +62,7 @@ class ViValidationError(ViError):
         message: str,
         error_id: str | None = None,
         validation_errors: list[dict[str, Any]] | None = None,
+        error_type: str | None = None,
     ) -> None:
         """Initialize validation error.
 
@@ -56,6 +70,7 @@ class ViValidationError(ViError):
             message: The error message.
             error_id: Optional unique error ID.
             validation_errors: List of detailed validation issues.
+            error_type: Optional Viessmann API error classification.
         """
         detailed_msg = message
         if validation_errors:
@@ -68,7 +83,7 @@ class ViValidationError(ViError):
             )
             detailed_msg = f"{message}: {details}"
 
-        super().__init__(detailed_msg, error_id)
+        super().__init__(detailed_msg, error_id, error_type)
         self.validation_errors = validation_errors
 
 

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -14,6 +14,7 @@ from .models import (
     Feature,
     FeatureControl,
     Gateway,
+    GatewayDeviceRefreshResult,
     Installation,
 )
 from .parsing import parse_feature_flat
@@ -206,6 +207,33 @@ class MockViClient(ViClient):
             filtered.append(feature)
 
         return filtered
+
+    async def update_gateway_devices(
+        self, devices: list[Device]
+    ) -> GatewayDeviceRefreshResult:
+        """Refresh gateway devices from fixtures without network access.
+
+        Args:
+            devices: Existing devices belonging to one installation and gateway.
+
+        Returns:
+            Refreshed devices in input order with no device-specific errors.
+
+        Raises:
+            ValueError: If devices span multiple scopes or contain duplicate IDs.
+        """
+        if not devices:
+            return GatewayDeviceRefreshResult([], {})
+
+        self._validate_gateway_devices(devices)
+        updated_devices = []
+        for device in devices:
+            features = await self.get_features(device, only_enabled=True)
+            enabled_and_ready_features = [
+                feature for feature in features if feature.is_ready
+            ]
+            updated_devices.append(replace(device, features=enabled_and_ready_features))
+        return GatewayDeviceRefreshResult(updated_devices, {})
 
     async def _execute_command(
         self,

--- a/src/vi_api_client/models.py
+++ b/src/vi_api_client/models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from .exceptions import ViError
+
 
 @dataclass(frozen=True)
 class FeatureControl:
@@ -135,6 +137,24 @@ class Device:
             device_type=data.get("deviceType", ""),
             status=data.get("status", ""),
         )
+
+
+@dataclass(frozen=True)
+class GatewayDeviceRefreshResult:
+    """Result of refreshing devices through one gateway-scoped request.
+
+    Attributes:
+        updated_devices: Devices whose enabled and ready features were refreshed.
+        errors_by_device_id: Device-specific failures keyed by device ID.
+    """
+
+    updated_devices: list[Device]
+    errors_by_device_id: dict[str, ViError]
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether every requested device was refreshed."""
+        return not self.errors_by_device_id
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/gateway_device_features.json
+++ b/tests/fixtures/gateway_device_features.json
@@ -1,0 +1,77 @@
+{
+  "data": [
+    {
+      "feature": "heating.sensors.temperature.outside",
+      "properties": {
+        "value": {
+          "unit": "celsius",
+          "value": 5.5
+        }
+      },
+      "isEnabled": true,
+      "isReady": true,
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/devices/0/features/heating.sensors.temperature.outside"
+    },
+    {
+      "commands": {
+        "setCurve": {
+          "isExecutable": true,
+          "params": {
+            "shift": {
+              "required": true,
+              "type": "number"
+            },
+            "slope": {
+              "required": true,
+              "type": "number"
+            }
+          },
+          "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/devices/0/features/heating.circuits.0.heating.curve/commands/setCurve"
+        }
+      },
+      "feature": "heating.circuits.0.heating.curve",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "shift": {
+          "unit": "celsius",
+          "value": 0
+        },
+        "slope": {
+          "value": 0.7
+        }
+      },
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/devices/0/features/heating.circuits.0.heating.curve"
+    },
+    {
+      "feature": "heating.sensors.temperature.supply",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": {
+          "unit": "celsius",
+          "value": 34.2
+        }
+      },
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/devices/10/features/heating.sensors.temperature.supply"
+    },
+    {
+      "feature": "gateway.status",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": "connected"
+      },
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/features/gateway.status"
+    },
+    {
+      "feature": "device.serial",
+      "isEnabled": true,
+      "isReady": true,
+      "properties": {
+        "value": "unrequested"
+      },
+      "uri": "https://api.viessmann-climatesolutions.com/iot/v2/features/installations/installation-1/gateways/gateway-1/devices/99/features/device.serial"
+    }
+  ]
+}

--- a/tests/integration/test_workflow_mock.py
+++ b/tests/integration/test_workflow_mock.py
@@ -161,3 +161,36 @@ async def test_mock_workflow_auto_hydration():
     temp = device.get_feature("heating.sensors.temperature.outside")
     assert temp is not None
     assert temp.value == 9
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mock_gateway_device_refresh_stays_offline():
+    """Verify gateway-scoped refresh has offline mock parity."""
+    # Arrange: Use two known devices on the same mock gateway.
+    client = MockViClient("Vitodens200W")
+    client.connector.post = AsyncMock()
+    devices = [
+        Device(
+            id=device_id,
+            gateway_serial="MOCK_GW",
+            installation_id="99999",
+            model_id=f"model-{device_id}",
+            device_type="heating",
+            status="connected",
+        )
+        for device_id in ("10", "0")
+    ]
+
+    # Act: Refresh both devices through the gateway-scoped public API.
+    result = await client.update_gateway_devices(devices)
+
+    # Assert: Mock refresh preserves order and metadata without HTTP access.
+    client.connector.post.assert_not_awaited()
+    assert result.is_complete
+    assert [device.id for device in result.updated_devices] == ["10", "0"]
+    assert [device.model_id for device in result.updated_devices] == [
+        "model-10",
+        "model-0",
+    ]
+    assert all(device.features for device in result.updated_devices)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,8 +17,13 @@ from vi_api_client.const import (
     ENDPOINT_INSTALLATIONS,
 )
 from vi_api_client.exceptions import (
+    ViAuthError,
+    ViConnectionError,
     ViNotFoundError,
+    ViRateLimitError,
+    ViResponseError,
     ViServerInternalError,
+    ViValidationError,
 )
 from vi_api_client.models import Device, FeatureControl
 
@@ -32,6 +37,348 @@ class MockAuth(AbstractAuth):
 
     async def async_get_access_token(self) -> str:
         return self._access_token
+
+
+def _build_gateway_device(device_id: str) -> Device:
+    """Build a device for gateway-scoped refresh tests."""
+    return Device(
+        id=device_id,
+        gateway_serial="gateway-1",
+        installation_id="installation-1",
+        model_id=f"model-{device_id}",
+        device_type="heating",
+        status="connected",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_refreshes_multiple_devices_with_one_request(
+    load_fixture_json,
+):
+    # Arrange: Mock a gateway response with requested and unrelated features.
+    response = load_fixture_json("gateway_device_features.json")
+    devices = [_build_gateway_device("10"), _build_gateway_device("0")]
+    url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/features/filter"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload=response)
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act: Refresh both devices through the public gateway operation.
+            result = await client.update_gateway_devices(devices)
+
+    # Assert: Both devices are refreshed in input order by one bulk request.
+    assert result.is_complete
+    assert [device.id for device in result.updated_devices] == ["10", "0"]
+    assert result.updated_devices[0].model_id == "model-10"
+    assert (
+        result.updated_devices[0]
+        .get_feature("heating.sensors.temperature.supply")
+        .value
+        == 34.2
+    )
+    assert (
+        result.updated_devices[1]
+        .get_feature("heating.sensors.temperature.outside")
+        .value
+        == 5.5
+    )
+    assert (
+        result.updated_devices[1]
+        .get_feature("heating.circuits.0.heating.curve.slope")
+        .is_writable
+    )
+    assert len(mock_responses.requests) == 1
+    request = next(iter(mock_responses.requests.values()))[0]
+    assert request.kwargs["json"] == {
+        "includeDevicesFeatures": True,
+        "skipDisabled": True,
+        "skipNotReady": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_decodes_complete_device_uri_segments():
+    # Arrange: Return a feature for a device ID containing an encoded slash.
+    response = {
+        "data": [
+            {
+                "feature": "heating.status",
+                "properties": {"value": "ready"},
+                "uri": (
+                    "/iot/v2/features/installations/installation-1/gateways/"
+                    "gateway-1/devices/device%2F0/features/heating.status"
+                ),
+            }
+        ]
+    }
+    device = _build_gateway_device("device/0")
+    url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/features/filter"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload=response)
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act: Refresh the encoded device ID.
+            result = await client.update_gateway_devices([device])
+
+    # Assert: The decoded complete segment maps to the requested device.
+    assert result.is_complete
+    assert result.updated_devices[0].id == "device/0"
+    assert result.updated_devices[0].get_feature("heating.status").value == "ready"
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_accepts_empty_input_without_request():
+    # Arrange: Create a client without registering any HTTP response.
+    async with aiohttp.ClientSession() as session:
+        client = ViClient(MockAuth(session))
+
+        # Act: Refresh an empty gateway device collection.
+        result = await client.update_gateway_devices([])
+
+    # Assert: Empty input is a complete result and performs no I/O.
+    assert result.is_complete
+    assert result.updated_devices == []
+    assert result.errors_by_device_id == {}
+
+
+@pytest.mark.parametrize(
+    ("devices", "message"),
+    [
+        (
+            [
+                _build_gateway_device("0"),
+                replace(_build_gateway_device("1"), gateway_serial="gateway-2"),
+            ],
+            "same installation and gateway",
+        ),
+        (
+            [
+                _build_gateway_device("0"),
+                replace(_build_gateway_device("1"), installation_id="installation-2"),
+            ],
+            "same installation and gateway",
+        ),
+        (
+            [_build_gateway_device("0"), _build_gateway_device("0")],
+            "unique IDs",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_gateway_devices_rejects_ambiguous_device_sets(
+    devices: list[Device], message: str
+):
+    # Arrange: Create a client without registering any HTTP response.
+    async with aiohttp.ClientSession() as session:
+        client = ViClient(MockAuth(session))
+
+        # Act and assert: Invalid device collections fail before network access.
+        with pytest.raises(ValueError, match=message):
+            await client.update_gateway_devices(devices)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        [],
+        {"data": {}},
+        {"data": ["not-an-object"]},
+        {"data": [{"uri": "/iot/v2/features/devices"}]},
+        {"data": [{"uri": "/iot/v2/features/devices/%ZZ/features/heating"}]},
+        {"data": [{"uri": "/iot/v2/features/devices/0/features/missing.feature"}]},
+        {"data": [{"uri": ("/iot/v2/features/devices/0/features/devices/10/heating")}]},
+        {
+            "data": [
+                {
+                    "uri": "/iot/v2/features/devices/0/features/heating",
+                    "properties": [],
+                }
+            ]
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_gateway_devices_rejects_invalid_bulk_responses(response):
+    # Arrange: Return a malformed successful response from the gateway endpoint.
+    url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/features/filter"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload=response)
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: Invalid response ownership is a public response error.
+            with pytest.raises(ViResponseError):
+                await client.update_gateway_devices([_build_gateway_device("0")])
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_falls_back_only_for_missing_devices(
+    load_fixture_json,
+):
+    # Arrange: The bulk response includes device 10 but omits device 0.
+    fixture = load_fixture_json("gateway_device_features.json")
+    bulk_response = {
+        "data": [
+            feature for feature in fixture["data"] if "/devices/10/" in feature["uri"]
+        ]
+    }
+    devices = [_build_gateway_device("10"), _build_gateway_device("0")]
+    gateway_url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/features/filter"
+    )
+    device_url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/devices/0/features/filter"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(gateway_url, payload=bulk_response)
+        mock_responses.post(device_url, payload={"data": []})
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act: Refresh the two devices.
+            result = await client.update_gateway_devices(devices)
+
+    # Assert: Only the absent device uses the fallback; empty features are successful.
+    assert result.is_complete
+    assert [device.id for device in result.updated_devices] == ["10", "0"]
+    assert result.updated_devices[1].features == []
+    assert len(mock_responses.requests) == 2
+    assert any(
+        method == "POST" and str(request_url) == device_url
+        for method, request_url in mock_responses.requests
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type"),
+    [
+        (400, "DEVICE_COMMUNICATION_ERROR"),
+        (404, "DEVICE_NOT_FOUND"),
+        (403, "PACKAGE_NOT_PAID_FOR"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_gateway_devices_captures_device_specific_fallback_errors(
+    status: int, error_type: str, load_fixture_json
+):
+    # Arrange: Gateway communication fails and device 0 then fails specifically.
+    fixture = load_fixture_json("gateway_device_features.json")
+    device_10_response = {
+        "data": [
+            feature for feature in fixture["data"] if "/devices/10/" in feature["uri"]
+        ]
+    }
+    base_url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/gateway-1"
+    devices = [_build_gateway_device("10"), _build_gateway_device("0")]
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(
+            f"{base_url}/features/filter",
+            status=400,
+            payload={
+                "message": "Gateway unavailable",
+                "errorType": "DEVICE_COMMUNICATION_ERROR",
+            },
+        )
+        mock_responses.post(
+            f"{base_url}/devices/10/features/filter", payload=device_10_response
+        )
+        mock_responses.post(
+            f"{base_url}/devices/0/features/filter",
+            status=status,
+            payload={"message": "Device unavailable", "errorType": error_type},
+        )
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act: Refresh through the public gateway operation.
+            result = await client.update_gateway_devices(devices)
+
+    # Assert: Successful devices and per-device errors remain independent.
+    assert not result.is_complete
+    assert [device.id for device in result.updated_devices] == ["10"]
+    assert set(result.errors_by_device_id) == {"0"}
+    assert result.errors_by_device_id["0"].error_type == error_type
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "expected_error"),
+    [
+        (401, "UNAUTHORIZED", ViAuthError),
+        (429, "RATE_LIMIT_EXCEEDED", ViRateLimitError),
+        (500, "INTERNAL_ERROR", ViServerInternalError),
+        (400, "UNKNOWN_VALIDATION_ERROR", ViValidationError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_gateway_devices_propagates_global_gateway_errors(
+    status: int, error_type: str, expected_error: type[Exception]
+):
+    # Arrange: Return a non-fallback gateway error.
+    url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/features/filter"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(
+            url,
+            status=status,
+            payload={"message": "Global failure", "errorType": error_type},
+        )
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: Global failures abort the entire refresh.
+            with pytest.raises(expected_error):
+                await client.update_gateway_devices([_build_gateway_device("0")])
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_propagates_connection_errors():
+    # Arrange: Do not register the bulk endpoint, causing a network failure.
+    with aioresponses():
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: Connection failures abort the entire refresh.
+            with pytest.raises(ViConnectionError):
+                await client.update_gateway_devices([_build_gateway_device("0")])
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_devices_translates_malformed_fallback_response():
+    # Arrange: Trigger fallback and return invalid feature properties.
+    base_url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/gateway-1"
+    with aioresponses() as mock_responses:
+        mock_responses.post(f"{base_url}/features/filter", payload={"data": []})
+        mock_responses.post(
+            f"{base_url}/devices/0/features/filter",
+            payload={"data": [{"feature": "broken", "properties": []}]},
+        )
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: Fallback contract failures use the public error.
+            with pytest.raises(ViResponseError):
+                await client.update_gateway_devices([_build_gateway_device("0")])
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -4,10 +4,20 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
+from aioresponses import aioresponses
 
 from vi_api_client.auth import AbstractAuth
 from vi_api_client.connection import ViConnector
-from vi_api_client.exceptions import ViConnectionError
+from vi_api_client.const import API_BASE_URL
+from vi_api_client.exceptions import (
+    ViAuthError,
+    ViConnectionError,
+    ViError,
+    ViNotFoundError,
+    ViRateLimitError,
+    ViServerInternalError,
+    ViValidationError,
+)
 
 
 class _ExternalOAuthError(aiohttp.ClientResponseError):
@@ -67,3 +77,52 @@ async def test_connector_wraps_aiohttp_connection_error() -> None:
     with pytest.raises(ViConnectionError) as raised_error:
         await connector.get("/installations")
     assert raised_error.value.__cause__ is connection_error
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_error"),
+    [
+        (400, ViValidationError),
+        (401, ViAuthError),
+        (403, ViAuthError),
+        (404, ViNotFoundError),
+        (418, ViError),
+        (429, ViRateLimitError),
+        (500, ViServerInternalError),
+    ],
+)
+@pytest.mark.asyncio
+async def test_connector_preserves_viessmann_error_type(
+    status: int, expected_error: type[Exception]
+) -> None:
+    # Arrange: Return a structured Viessmann error from the HTTP boundary.
+    url = f"{API_BASE_URL}/features"
+    payload = {
+        "errorType": "DEVICE_COMMUNICATION_ERROR",
+        "message": "Device communication failed",
+        "viErrorId": "error-123",
+    }
+
+    with aioresponses() as mock_responses:
+        mock_responses.get(url, payload=payload, status=status)
+        async with aiohttp.ClientSession() as session:
+            connector = ViConnector(_StaticAuth(session))
+
+            # Act and assert: The public exception retains API classification data.
+            with pytest.raises(expected_error) as raised_error:
+                await connector.get("/features")
+            assert raised_error.value.error_id == "error-123"
+            assert raised_error.value.error_type == "DEVICE_COMMUNICATION_ERROR"
+
+
+def test_validation_error_keeps_existing_positional_arguments() -> None:
+    # Arrange: Use the public positional signature supported before error types.
+    validation_errors = [{"message": "Invalid", "path": "feature"}]
+
+    # Act: Construct the error with its existing three positional arguments.
+    error = ViValidationError("Bad request", "error-123", validation_errors)
+
+    # Assert: Existing arguments retain their meaning and error type is optional.
+    assert error.error_id == "error-123"
+    assert error.error_type is None
+    assert error.validation_errors == validation_errors

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,13 @@
 """Tests for data models (Flat Architecture)."""
 
-from vi_api_client.models import Device, Feature, FeatureControl
+import vi_api_client
+from vi_api_client.exceptions import ViError, ViResponseError
+from vi_api_client.models import (
+    Device,
+    Feature,
+    FeatureControl,
+    GatewayDeviceRefreshResult,
+)
 
 
 def test_feature_dataclass():
@@ -95,3 +102,35 @@ def test_device_from_api():
     # Assert: Device should have API data correctly mapped to model fields.
     assert d.id == "dev1"
     assert d.model_id == "complex_model"
+
+
+def test_gateway_device_refresh_result_reports_completeness():
+    # Arrange: Create one refreshed device and one device-specific error.
+    refreshed_device = Device(
+        id="device-0",
+        gateway_serial="gateway-1",
+        installation_id="installation-1",
+        model_id="Vitocal250A",
+        device_type="heating",
+        status="connected",
+    )
+    error = ViError("device unavailable")
+
+    # Act: Build complete and partial gateway device refresh results.
+    complete_result = GatewayDeviceRefreshResult(
+        updated_devices=[refreshed_device], errors_by_device_id={}
+    )
+    partial_result = GatewayDeviceRefreshResult(
+        updated_devices=[refreshed_device],
+        errors_by_device_id={"device-1": error},
+    )
+
+    # Assert: Completeness depends only on the device-specific error mapping.
+    assert complete_result.is_complete
+    assert not partial_result.is_complete
+
+
+def test_gateway_refresh_public_types_are_exported():
+    # Act and assert: New public contracts are available from the package root.
+    assert vi_api_client.GatewayDeviceRefreshResult is GatewayDeviceRefreshResult
+    assert vi_api_client.ViResponseError is ViResponseError


### PR DESCRIPTION
## Summary

- add an explicit gateway-scoped bulk refresh for known devices
- preserve successful device updates while isolating documented device-specific failures
- add targeted per-device fallback, response validation, error type metadata, and offline `MockViClient` parity
- document the public contract, domain terminology, and architecture decision

## Testing

- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q` (132 passed, 81% coverage)
- `python -m build`

Consumer changes, including `vi_climate_devices`, remain out of scope.

Closes #42
