### PR TITLE
Add centralized quality checks and configure Pyright

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -23,12 +23,8 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -c constraints-ci.txt .[dev]
-    - name: Lint & Format (Ruff)
-      run: |
-        ruff check .
-        ruff format --check .
-    - name: Tests
-      run: pytest
+    - name: Quality check
+      run: python scripts/quality_check.py
 
   release:
     needs: quality-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+minimum_pre_commit_version: "4.6.2"
+
+repos:
+  - repo: local
+    hooks:
+      - id: quality-check
+        name: Quality check
+        entry: .venv/bin/python scripts/quality_check.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ tested HTTP client and mock combination locally:
 
 ```bash
 python -m pip install -c constraints-ci.txt '.[dev]'
+pre-commit install
 ruff check .
 ruff format --check .
+pyright --pythonpath python
 python -m pytest -q
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dev = [
     "pytest>=9",
     "pytest-asyncio>=1.3",
     "pytest-cov>=7.1",
+    "pyright==1.1.411",
+    "pre-commit==4.6.2",
     "ruff==0.16.5",
 ]
 
@@ -68,3 +70,9 @@ convention = "google"
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
+
+[tool.pyright]
+include = ["src", "tests", "demo_simple.py", "demo_live.py"]
+exclude = [".venv", "build", "dist"]
+pythonVersion = "3.14"
+typeCheckingMode = "standard"

--- a/scripts/quality_check.py
+++ b/scripts/quality_check.py
@@ -1,0 +1,29 @@
+"""Run the repository's complete local quality gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+COMMANDS = (
+    (sys.executable, "-m", "ruff", "check", "."),
+    (sys.executable, "-m", "ruff", "format", "--check", "."),
+    (sys.executable, "-m", "pyright", "--pythonpath", sys.executable),
+    (sys.executable, "-m", "pytest", "-q"),
+)
+
+
+def main() -> int:
+    """Run every quality command and stop at the first failure."""
+    for command in COMMANDS:
+        result = subprocess.run(command, cwd=PROJECT_ROOT, check=False)
+        if result.returncode:
+            return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -135,7 +135,10 @@ class ViClient:
             List of Feature objects (flattened).
         """
         url = self._build_features_url(device)
-        payload = {"skipDisabled": only_enabled, "skipNotReady": only_enabled}
+        payload: dict[str, bool | list[str]] = {
+            "skipDisabled": only_enabled,
+            "skipNotReady": only_enabled,
+        }
         if feature_names:
             payload["filter"] = feature_names
 
@@ -601,15 +604,10 @@ class ViClient:
             self._validate_enum_constraints(ctrl, value)
 
         # Type-specific Dispatch
-        validators = {
-            int: self._validate_numeric_constraints,
-            float: self._validate_numeric_constraints,
-            str: self._validate_string_constraints,
-        }
-
-        validator = validators.get(type(value))
-        if validator:
-            validator(ctrl, value)  # type: ignore
+        if isinstance(value, int | float):
+            self._validate_numeric_constraints(ctrl, value)
+        elif isinstance(value, str):
+            self._validate_string_constraints(ctrl, value)
 
     def _validate_numeric_constraints(
         self, ctrl: FeatureControl, value: int | float

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -221,6 +221,12 @@ async def setup_client_context(
                     f"Dev={dev_id}"
                 )
 
+        if not (inst_id and gw_serial and dev_id):
+            raise ValueError(
+                "Installation ID, gateway serial, and device ID are required when "
+                "auto-discovery is disabled."
+            )
+
         yield CLIContext(session, client, inst_id, gw_serial, dev_id)
 
 
@@ -716,6 +722,8 @@ async def cmd_list_writable(args) -> bool:
 
             for feature in writable_features:
                 ctrl = feature.control
+                if ctrl is None:
+                    continue
                 print(f"- {feature.name}")
                 print(f"    Param:   {ctrl.param_name} (via {ctrl.command_name})")
                 _print_feature_constraints(ctrl)

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -237,22 +237,22 @@ class MockViClient(ViClient):
 
     async def _execute_command(
         self,
-        ctrl: FeatureControl,
-        params: dict[str, Any],
+        control: FeatureControl,
+        payload: dict[str, Any],
     ) -> CommandResponse:
         """Mock execution of a command (Success).
 
         Args:
-            ctrl: The feature control block being executed.
-            params: Validated parameters for the command.
+            control: The feature control block being executed.
+            payload: Validated parameters for the command.
 
         Returns:
             A CommandResponse indicating success.
         """
         print(
-            f"[MOCK] Executing command '{ctrl.command_name}' for feature "
-            f"'{ctrl.parent_feature_name}' (param: {ctrl.param_name}) "
-            f"with params: {params}"
+            f"[MOCK] Executing command '{control.command_name}' for feature "
+            f"'{control.parent_feature_name}' (param: {control.param_name}) "
+            f"with params: {payload}"
         )
         return CommandResponse(success=True, reason="Mock Execution Success")
 

--- a/src/vi_api_client/models.py
+++ b/src/vi_api_client/models.py
@@ -95,7 +95,9 @@ class Device:
     features: list[Feature] = field(default_factory=list)
 
     # Internal cache for O(1) lookup
-    _features_by_name: dict[str, Feature] = field(init=False, repr=False, default=None)
+    _features_by_name: dict[str, Feature] = field(
+        init=False, repr=False, default_factory=dict
+    )
 
     def __post_init__(self) -> None:
         """Build internal cache."""

--- a/tests/integration/test_workflow_mock.py
+++ b/tests/integration/test_workflow_mock.py
@@ -104,6 +104,7 @@ async def test_mock_workflow_vitocal():
         ),
         None,
     )
+    assert circuit_mode is not None
     assert circuit_mode.is_writable is True
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -75,23 +75,21 @@ async def test_update_gateway_devices_refreshes_multiple_devices_with_one_reques
     assert result.is_complete
     assert [device.id for device in result.updated_devices] == ["10", "0"]
     assert result.updated_devices[0].model_id == "model-10"
-    assert (
-        result.updated_devices[0]
-        .get_feature("heating.sensors.temperature.supply")
-        .value
-        == 34.2
+    supply_temperature = result.updated_devices[0].get_feature(
+        "heating.sensors.temperature.supply"
     )
-    assert (
-        result.updated_devices[1]
-        .get_feature("heating.sensors.temperature.outside")
-        .value
-        == 5.5
+    outside_temperature = result.updated_devices[1].get_feature(
+        "heating.sensors.temperature.outside"
     )
-    assert (
-        result.updated_devices[1]
-        .get_feature("heating.circuits.0.heating.curve.slope")
-        .is_writable
+    heating_curve_slope = result.updated_devices[1].get_feature(
+        "heating.circuits.0.heating.curve.slope"
     )
+    assert supply_temperature is not None
+    assert outside_temperature is not None
+    assert heating_curve_slope is not None
+    assert supply_temperature.value == 34.2
+    assert outside_temperature.value == 5.5
+    assert heating_curve_slope.is_writable
     assert len(mock_responses.requests) == 1
     request = next(iter(mock_responses.requests.values()))[0]
     assert request.kwargs["json"] == {
@@ -133,7 +131,9 @@ async def test_update_gateway_devices_decodes_complete_device_uri_segments():
     # Assert: The decoded complete segment maps to the requested device.
     assert result.is_complete
     assert result.updated_devices[0].id == "device/0"
-    assert result.updated_devices[0].get_feature("heating.status").value == "ready"
+    heating_status = result.updated_devices[0].get_feature("heating.status")
+    assert heating_status is not None
+    assert heating_status.value == "ready"
 
 
 @pytest.mark.asyncio
@@ -842,6 +842,7 @@ async def test_set_feature_with_dependency(load_fixture_json):
             # 3. Find the 'slope' feature
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
             assert slope_feature is not None
+            assert slope_feature is not None
 
             # Act: Set slope to 1.2 and verify dependency resolution.
             # The fixture says 'shift' is 4.
@@ -889,6 +890,7 @@ async def test_set_feature_validation_limit(load_fixture_json):
             device = replace(device, features=await client.get_features(device))
 
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
 
             # Act & Assert: Max limit violation (Max is 3.5).
             with pytest.raises(ValueError, match=r"Value 5.0 > max"):
@@ -921,6 +923,7 @@ async def test_set_feature_validation_step(load_fixture_json):
             device = replace(device, features=await client.get_features(device))
 
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
 
             # Act & Assert: Step violation (Step is 0.1, 1.25 is invalid).
             with pytest.raises(ValueError, match=r"does not align with step"):
@@ -964,6 +967,7 @@ async def test_set_feature_returns_updated_device(load_fixture_json):
             device = replace(base_device, features=features)
 
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
             original_slope = slope_feature.value  # Should be 0.6 from fixture
 
             # Act: Set slope to new value.
@@ -976,6 +980,7 @@ async def test_set_feature_returns_updated_device(load_fixture_json):
             updated_slope_feature = updated_device.get_feature(
                 "heating.circuits.0.heating.curve.slope"
             )
+            assert updated_slope_feature is not None
             assert updated_slope_feature.value == 0.7
             assert original_slope == 0.6  # Original unchanged
 
@@ -1020,6 +1025,7 @@ async def test_set_feature_returns_unchanged_device_on_failure(load_fixture_json
             device = replace(base_device, features=features)
 
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
             original_slope = slope_feature.value
 
             # Act: Try to set value but command fails.
@@ -1033,6 +1039,7 @@ async def test_set_feature_returns_unchanged_device_on_failure(load_fixture_json
             returned_slope_feature = updated_device.get_feature(
                 "heating.circuits.0.heating.curve.slope"
             )
+            assert returned_slope_feature is not None
             assert returned_slope_feature.value == original_slope
 
 
@@ -1077,6 +1084,8 @@ async def test_interdependent_features_use_optimistic_values(load_fixture_json):
 
             slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
             shift_feature = device.get_feature("heating.circuits.0.heating.curve.shift")
+            assert slope_feature is not None
+            assert shift_feature is not None
 
             # Act: Set slope first to 0.7.
             response1, device = await client.set_feature(device, slope_feature, 0.7)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -18,7 +18,7 @@ def test_abstract_auth_cannot_be_instantiated():
     """AbstractAuth should not be instantiated directly."""
     # Arrange, Act and Assert: Complete test in one step.
     with pytest.raises(TypeError):
-        AbstractAuth(MagicMock())
+        AbstractAuth(MagicMock())  # type: ignore[reportAbstractUsage]
 
 
 @pytest.fixture

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -605,7 +605,7 @@ async def test_cmd_list_devices(mock_cli_context, capsys):
     )
 
     # Mock Data (Objects)
-    inst = Installation(id=123, description="Home", alias="MyHome", address={})
+    inst = Installation(id="123", description="Home", alias="MyHome", address={})
     gw = Gateway(serial="GW1", version="1.0", status="ok", installation_id="123")
     dev = Device(
         id="0",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -93,7 +93,7 @@ async def test_connector_wraps_aiohttp_connection_error() -> None:
 )
 @pytest.mark.asyncio
 async def test_connector_preserves_viessmann_error_type(
-    status: int, expected_error: type[Exception]
+    status: int, expected_error: type[ViError]
 ) -> None:
     # Arrange: Return a structured Viessmann error from the HTTP boundary.
     url = f"{API_BASE_URL}/features"

--- a/tests/test_hysteresis_parsing.py
+++ b/tests/test_hysteresis_parsing.py
@@ -32,11 +32,14 @@ def test_hysteresis_parsing(load_fixture_json):
 
     # Check Controls.
     assert feature_value.is_writable
+    assert feature_value.control is not None
     assert feature_value.control.command_name == "setHysteresis"
 
     # These currently FAIL because of the missing mapping logic.
     assert feature_on.is_writable
+    assert feature_on.control is not None
     assert feature_on.control.command_name == "setHysteresisSwitchOnValue"
 
     assert feature_off.is_writable
+    assert feature_off.control is not None
     assert feature_off.control.command_name == "setHysteresisSwitchOffValue"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -55,6 +55,7 @@ def test_feature_writable():
 
     # Assert: Feature should be writable and have constraint values from control.
     assert feature.is_writable is True
+    assert feature.control is not None
     assert feature.control.min == 0
     assert feature.control.max == 100
     assert feature.control.value_type == "number"


### PR DESCRIPTION
## Summary

- Add Pyright configuration and pin Pyright and pre-commit development dependencies.
- Introduce a shared quality-check script for Ruff, formatting, type checking, and tests.
- Run the centralized quality gate in CI and through a pre-commit hook.
- Apply type-safety fixes across the client, CLI, models, mock client, and tests.

## Testing

- Quality checks are centralized through `scripts/quality_check.py`, covering Ruff, formatting, Pyright, and the test suite.