### PR TITLE
feat(auth): centralize credential persistence

### DIFF
--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -83,6 +83,12 @@ If the token file contains invalid JSON, `OAuth` leaves it untouched and raises
 `ViAuthError`. Repair or remove that file before authenticating again; this avoids
 silently losing credentials or saved client configuration.
 
+Credential updates preserve unrelated JSON fields, are written through a temporary
+file in the same directory, and then atomically replace the previous file. On
+platforms that support POSIX permissions, the resulting credential file is
+owner-readable and owner-writable only (`0600`). The parent directory must already
+exist; `OAuth` does not create it automatically.
+
 (The `OAuth` class implements the PKCE flow internally).
 
 ## Token Format

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -1,11 +1,9 @@
 """Authentication module for Viessmann API."""
 
-import json
 import logging
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 from types import TracebackType
 from typing import Any, Self
 from urllib.parse import urlencode
@@ -14,6 +12,7 @@ import aiohttp
 import pkce
 
 from .const import DEFAULT_SCOPES, ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
+from .credentials import CredentialDocument
 from .exceptions import ViAuthError, ViConnectionError
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,6 +111,7 @@ class OAuth(AbstractAuth):
         self.client_id = client_id
         self.redirect_uri = redirect_uri
         self.token_file = Path(token_file)
+        self._credential_document = CredentialDocument(self.token_file)
         self.scope = scope
         self._token_info: dict[str, Any] = {}
         self._pkce_verifier: str | None = None
@@ -121,38 +121,11 @@ class OAuth(AbstractAuth):
 
     def _load_tokens(self) -> None:
         """Load tokens from file."""
-        self._token_info = self._read_token_file()
-
-    def _read_token_file(self) -> dict[str, Any]:
-        """Read token data without silently replacing malformed files."""
-        try:
-            with self.token_file.open(encoding="utf-8") as file:
-                return json.load(file)
-        except FileNotFoundError:
-            return {}
-        except json.JSONDecodeError as error:
-            raise ViAuthError(
-                f"Token file '{self.token_file}' contains invalid JSON and was not "
-                "modified. Repair or remove the file before authenticating again."
-            ) from error
+        self._token_info = self._credential_document.read()
 
     def _save_tokens(self) -> None:
         """Save tokens to file, preserving existing content."""
-        current_data = self._read_token_file()
-        current_data.update(self._token_info)
-
-        with NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=self.token_file.parent,
-            prefix=f".{self.token_file.name}.",
-            suffix=".tmp",
-            delete=False,
-        ) as file:
-            json.dump(current_data, file, indent=2)
-            temporary_file = Path(file.name)
-
-        temporary_file.replace(self.token_file)
+        self._credential_document.update(self._token_info)
 
     def get_authorization_url(self) -> str:
         """Generate authorization URL and PKCE challenge."""

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -24,6 +24,7 @@ from vi_api_client import (
     ViValidationError,
 )
 
+from .credentials import CredentialDocument
 from .models import CommandResponse, Device, Feature
 from .utils import format_feature, parse_cli_params
 
@@ -55,12 +56,11 @@ def load_config(token_file: str) -> dict[str, Any]:
 
     Returns:
         Dictionary containing tokens and config, or empty dict if missing.
+
+    Raises:
+        ViAuthError: If the credential document cannot be read or is malformed.
     """
-    try:
-        with Path(token_file).open() as file:
-            return json.load(file)
-    except FileNotFoundError, json.JSONDecodeError:
-        return {}
+    return CredentialDocument(Path(token_file)).read()
 
 
 def _save_client_config(token_file: str, client_id: str, redirect_uri: str) -> None:
@@ -71,11 +71,9 @@ def _save_client_config(token_file: str, client_id: str, redirect_uri: str) -> N
         client_id: OAuth client ID used for authentication.
         redirect_uri: OAuth redirect URI used for authentication.
     """
-    config = load_config(token_file)
-    config.update({"client_id": client_id, "redirect_uri": redirect_uri})
-
-    with Path(token_file).open("w", encoding="utf-8") as file:
-        json.dump(config, file, indent=2)
+    CredentialDocument(Path(token_file)).update(
+        {"client_id": client_id, "redirect_uri": redirect_uri}
+    )
 
 
 async def create_session(args) -> aiohttp.ClientSession:

--- a/src/vi_api_client/credentials.py
+++ b/src/vi_api_client/credentials.py
@@ -1,0 +1,94 @@
+"""Persistence for the OAuth credential document."""
+
+import json
+import os
+import stat
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+from .exceptions import ViAuthError
+
+
+class CredentialDocument:
+    """Read and safely replace one OAuth credential JSON document."""
+
+    def __init__(self, path: Path) -> None:
+        """Initialize the document at its configured path.
+
+        Args:
+            path: Location of the credential JSON document.
+        """
+        self.path = path
+
+    def read(self) -> dict[str, Any]:
+        """Return credential data, treating an absent document as empty.
+
+        Raises:
+            ViAuthError: If the document cannot be read or does not contain a JSON
+                object.
+        """
+        try:
+            with self.path.open(encoding="utf-8") as file:
+                data = json.load(file)
+        except FileNotFoundError:
+            return {}
+        except (json.JSONDecodeError, UnicodeDecodeError) as error:
+            raise ViAuthError(
+                f"Token file '{self.path}' contains invalid JSON and was not "
+                "modified. Repair or remove the file before authenticating again."
+            ) from error
+        except OSError as error:
+            raise ViAuthError(
+                f"Could not read token file '{self.path}': {error}"
+            ) from error
+
+        if not isinstance(data, dict):
+            raise ViAuthError(
+                f"Token file '{self.path}' must contain a JSON object and was not "
+                "modified. Repair or remove the file before authenticating again."
+            )
+        return data
+
+    def update(self, token_data: dict[str, Any]) -> None:
+        """Merge token data and atomically replace the credential document.
+
+        Args:
+            token_data: Credential fields that should replace matching saved fields.
+
+        Raises:
+            ViAuthError: If the existing document cannot be read or validated, the
+                parent directory is unavailable, or the document cannot be saved.
+        """
+        current_data = self.read()
+        current_data.update(token_data)
+        self._replace(current_data)
+
+    def _replace(self, data: dict[str, Any]) -> None:
+        """Write a sibling temporary file before atomically replacing the target."""
+        if not self.path.parent.is_dir():
+            raise ViAuthError(
+                f"Token file parent directory '{self.path.parent}' does not exist."
+            )
+
+        temporary_file: Path | None = None
+        try:
+            with NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as file:
+                temporary_file = Path(file.name)
+                json.dump(data, file, indent=2)
+
+            os.chmod(temporary_file, stat.S_IRUSR | stat.S_IWUSR)
+            os.replace(temporary_file, self.path)
+        except OSError as error:
+            if temporary_file is not None:
+                temporary_file.unlink(missing_ok=True)
+            raise ViAuthError(
+                f"Could not save token file '{self.path}': {error}"
+            ) from error

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,10 @@
 """Tests for vitoclient.auth module."""
 
 import json
+import os
+import stat
 import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import aiohttp
@@ -99,6 +102,25 @@ def test_oauth_rejects_malformed_token_file_without_modifying_it(tmp_path):
     assert token_file.read_text(encoding="utf-8") == invalid_content
 
 
+def test_oauth_rejects_invalid_utf8_token_file_without_modifying_it(tmp_path):
+    """Invalid UTF-8 token files should remain intact and raise a library error."""
+    # Arrange: Store bytes that cannot be decoded as the credential document.
+    token_file = tmp_path / "tokens.json"
+    invalid_content = b"\xff"
+    token_file.write_bytes(invalid_content)
+
+    # Act and assert: Loading should preserve the corrupted credential document.
+    with pytest.raises(ViAuthError, match="Repair or remove the file"):
+        OAuth(
+            client_id="test_client_id",
+            redirect_uri="http://localhost:4200/",
+            token_file=token_file,
+        )
+
+    # Assert: The original bytes should remain available for manual recovery.
+    assert token_file.read_bytes() == invalid_content
+
+
 def test_save_tokens_rejects_file_that_becomes_malformed(oauth):
     """Token saves should not overwrite a file corrupted after initialization."""
     # Arrange: Initialize OAuth, then replace its absent token file with invalid JSON.
@@ -112,6 +134,153 @@ def test_save_tokens_rejects_file_that_becomes_malformed(oauth):
 
     # Assert: The malformed token file should not be overwritten by the new token.
     assert oauth.token_file.read_text(encoding="utf-8") == invalid_content
+
+
+def test_save_tokens_merges_new_tokens_with_existing_configuration(oauth):
+    """Token updates should retain configuration and unknown stored fields."""
+    # Arrange: Store configuration and a field from a future credential format.
+    oauth.token_file.write_text(
+        json.dumps(
+            {
+                "client_id": "configured-client",
+                "custom_metadata": {"source": "user"},
+                "access_token": "old-token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    oauth._token_info = {"access_token": "new-token", "refresh_token": "refresh"}
+
+    # Act: Persist the updated token information.
+    oauth._save_tokens()
+
+    # Assert: Existing non-token content should survive the update.
+    assert json.loads(oauth.token_file.read_text(encoding="utf-8")) == {
+        "client_id": "configured-client",
+        "custom_metadata": {"source": "user"},
+        "access_token": "new-token",
+        "refresh_token": "refresh",
+    }
+
+
+def test_save_tokens_reports_missing_parent_directory_without_creating_it(tmp_path):
+    """Credential persistence should not create missing parent directories."""
+    # Arrange: Configure OAuth to write below a directory that does not exist.
+    missing_parent = tmp_path / "missing"
+    oauth = OAuth(
+        client_id="test_client_id",
+        redirect_uri="http://localhost:4200/",
+        token_file=missing_parent / "tokens.json",
+    )
+    oauth._token_info = {"access_token": "new-token"}
+
+    # Act and assert: Saving should explain the filesystem failure.
+    with pytest.raises(ViAuthError, match="parent directory"):
+        oauth._save_tokens()
+
+    # Assert: Persistence should not create the directory as a side effect.
+    assert not missing_parent.exists()
+
+
+def test_save_tokens_uses_atomic_replacement_in_the_token_directory(oauth, monkeypatch):
+    """Credential updates should replace the destination with a sibling temp file."""
+    # Arrange: Track the low-level replacement while preserving its behavior.
+    replacement_calls = []
+    original_replace = os.replace
+
+    def track_replace(source, destination):
+        replacement_calls.append((source, destination))
+        original_replace(source, destination)
+
+    monkeypatch.setattr("vi_api_client.credentials.os.replace", track_replace)
+    oauth._token_info = {"access_token": "new-token"}
+
+    # Act: Save new credentials.
+    oauth._save_tokens()
+
+    # Assert: The temporary file should be a sibling of the destination.
+    source, destination = replacement_calls[0]
+    assert Path(source).parent == oauth.token_file.parent
+    assert destination == oauth.token_file
+
+
+def test_save_tokens_preserves_original_file_when_replacement_fails(oauth, monkeypatch):
+    """Failed replacement should retain the previous credential document."""
+    # Arrange: Seed a credential document and make the final replacement fail.
+    original_content = '{"access_token": "old-token"}'
+    oauth.token_file.write_text(original_content, encoding="utf-8")
+    oauth._token_info = {"access_token": "new-token"}
+
+    def raise_replace(source, destination):
+        raise OSError("simulated replacement failure")
+
+    monkeypatch.setattr("vi_api_client.credentials.os.replace", raise_replace)
+
+    # Act and assert: A failed replacement should become a library auth error.
+    with pytest.raises(ViAuthError, match="save token"):
+        oauth._save_tokens()
+
+    # Assert: The old file and no temporary artifacts should remain.
+    assert oauth.token_file.read_text(encoding="utf-8") == original_content
+    assert list(oauth.token_file.parent.glob(".tokens.json.*.tmp")) == []
+
+
+def test_save_tokens_reports_temporary_file_write_failures(oauth, monkeypatch):
+    """Credential persistence should translate temporary-file creation failures."""
+    # Arrange: Make temporary-file creation fail before the token file is replaced.
+    oauth.token_file.write_text('{"access_token": "old-token"}', encoding="utf-8")
+    oauth._token_info = {"access_token": "new-token"}
+
+    def raise_temporary_file_error(*args, **kwargs):
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(
+        "vi_api_client.credentials.NamedTemporaryFile", raise_temporary_file_error
+    )
+
+    # Act and assert: The operating-system failure should be a library auth error.
+    with pytest.raises(ViAuthError, match="save token"):
+        oauth._save_tokens()
+
+    # Assert: A failed write should leave the existing credentials unchanged.
+    assert (
+        oauth.token_file.read_text(encoding="utf-8") == '{"access_token": "old-token"}'
+    )
+
+
+def test_save_tokens_removes_temporary_file_after_serialization_failure(
+    oauth, monkeypatch
+):
+    """A serialization failure should not leave a temporary credential file."""
+    # Arrange: Make writing the temporary JSON document fail after it is created.
+    oauth._token_info = {"access_token": "new-token"}
+
+    def raise_serialization_error(*args, **kwargs):
+        raise OSError("simulated serialization failure")
+
+    monkeypatch.setattr(
+        "vi_api_client.credentials.json.dump", raise_serialization_error
+    )
+
+    # Act and assert: Saving should report the error through the auth boundary.
+    with pytest.raises(ViAuthError, match="save token"):
+        oauth._save_tokens()
+
+    # Assert: The failed write should not leave credentials or temporary files behind.
+    assert not oauth.token_file.exists()
+    assert list(oauth.token_file.parent.glob(".tokens.json.*.tmp")) == []
+
+
+def test_save_tokens_restricts_file_permissions_to_owner(oauth):
+    """Credential documents should be owner-readable and owner-writable only."""
+    # Arrange: Prepare token data.
+    oauth._token_info = {"access_token": "new-token"}
+
+    # Act: Persist the credentials.
+    oauth._save_tokens()
+
+    # Assert: The file mode should not grant group or other access.
+    assert stat.S_IMODE(oauth.token_file.stat().st_mode) == 0o600
 
 
 @pytest.mark.asyncio
@@ -147,6 +316,36 @@ async def test_async_refresh_access_token(oauth_with_tokens, load_fixture_json):
 
         # Assert: Verify the results match expectations.
         assert oauth_with_tokens._token_info["access_token"] == "refreshed_access_token"
+        assert (
+            json.loads(oauth_with_tokens.token_file.read_text(encoding="utf-8"))[
+                "access_token"
+            ]
+            == "refreshed_access_token"
+        )
+
+
+@pytest.mark.asyncio
+async def test_code_exchange_persists_token_json(oauth, load_fixture_json):
+    """Successful code exchange should retain the credential JSON format."""
+    # Arrange: Start OAuth and mock a successful token endpoint response.
+    oauth.get_authorization_url()
+    token_data = load_fixture_json("auth_token.json")
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(ENDPOINT_TOKEN, payload=token_data)
+
+        async with aiohttp.ClientSession() as session:
+            oauth.websession = session
+
+            # Act: Exchange the authorization code for tokens.
+            await oauth.async_fetch_details_from_code("accepted-code")
+
+    # Assert: The persisted document should contain the existing token fields.
+    saved_tokens = json.loads(oauth.token_file.read_text(encoding="utf-8"))
+    assert saved_tokens["access_token"] == token_data["access_token"]
+    assert saved_tokens["refresh_token"] == token_data["refresh_token"]
+    assert saved_tokens["expires_in"] == token_data["expires_in"]
+    assert isinstance(saved_tokens["expires_at"], float)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- centralize OAuth and CLI credential-document persistence
- atomically replace credential files with owner-only permissions
- cover malformed files, merging, write failures, and OAuth persistence

Closes #46

## Validation
- .venv/bin/python -m pytest -q
- .venv/bin/pyright --pythonpath .venv/bin/python src tests
- .venv/bin/python -m ruff check .
- .venv/bin/python -m ruff format --check .