### PR TITLE
feat(cli): share credential persistence

### DIFF
--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -23,6 +23,8 @@ Follow the URL, log in, and paste the code back into the terminal.
 The client ID and redirect URI used during login are saved with the tokens, so
 later commands can reuse them without repeating `--client-id`. Environment
 variables and explicit command-line arguments continue to take precedence.
+If the credential document is malformed, the command exits unsuccessfully and
+leaves the file unchanged; repair or remove it before trying again.
 
 ## 2. List Devices
 View all installations, gateways, and devices available to your account.

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -48,34 +48,6 @@ class CLIContext:
     dev_id: str
 
 
-def load_config(token_file: str) -> dict[str, Any]:
-    """Load configuration from token file.
-
-    Args:
-        token_file: Path to the JSON token file.
-
-    Returns:
-        Dictionary containing tokens and config, or empty dict if missing.
-
-    Raises:
-        ViAuthError: If the credential document cannot be read or is malformed.
-    """
-    return CredentialDocument(Path(token_file)).read()
-
-
-def _save_client_config(token_file: str, client_id: str, redirect_uri: str) -> None:
-    """Save client configuration alongside the OAuth tokens.
-
-    Args:
-        token_file: Path to the JSON token and configuration file.
-        client_id: OAuth client ID used for authentication.
-        redirect_uri: OAuth redirect URI used for authentication.
-    """
-    CredentialDocument(Path(token_file)).update(
-        {"client_id": client_id, "redirect_uri": redirect_uri}
-    )
-
-
 async def create_session(args) -> aiohttp.ClientSession:
     """Create aiohttp session with optional insecure SSL.
 
@@ -113,14 +85,16 @@ async def cmd_login(args) -> bool:
         auth.websession = session
         await auth.async_fetch_details_from_code(code)
 
-    _save_client_config(args.token_file, client_id, redirect_uri)
+    CredentialDocument(Path(args.token_file)).update(
+        {"client_id": client_id, "redirect_uri": redirect_uri}
+    )
     print(f"Successfully authenticated! Tokens and config saved to {args.token_file}")
     return True
 
 
 def get_client_config(args) -> tuple[str, str]:
     """Get client_id and redirect_uri from args or file."""
-    config = load_config(args.token_file)
+    config = CredentialDocument(Path(args.token_file)).read()
 
     client_id = (
         args.client_id or os.getenv("VIESSMANN_CLIENT_ID") or config.get("client_id")
@@ -934,7 +908,7 @@ async def _dispatch_command(args: argparse.Namespace) -> int:
         not args.client_id and not os.getenv("VIESSMANN_CLIENT_ID")
     ):
         # Check config one last time before failing
-        config = load_config(args.token_file)
+        config = CredentialDocument(Path(args.token_file)).read()
         if not config.get("client_id"):
             print(
                 "Error: --client-id is required for initial login "

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -6,6 +6,7 @@ import pytest
 
 from vi_api_client.cli import (
     _dispatch_command,
+    async_main,
     cmd_exec,
     cmd_get_consumption,
     cmd_get_feature,
@@ -15,6 +16,7 @@ from vi_api_client.cli import (
     cmd_list_writable,
     cmd_login,
     cmd_set,
+    get_client_config,
     main,
 )
 from vi_api_client.exceptions import ViValidationError
@@ -253,7 +255,10 @@ async def test_cmd_login_uses_environment_config_and_persists_it(monkeypatch, tm
     """Login should reuse environment credentials and save them for later commands."""
     # Arrange: Seed a token file and provide client settings through the environment.
     token_file = tmp_path / "tokens.json"
-    token_file.write_text('{"access_token": "existing-token"}', encoding="utf-8")
+    token_file.write_text(
+        '{"access_token": "existing-token", "future_field": "preserve-me"}',
+        encoding="utf-8",
+    )
     args = Namespace(
         client_id=None,
         insecure=False,
@@ -291,7 +296,68 @@ async def test_cmd_login_uses_environment_config_and_persists_it(monkeypatch, tm
         "access_token": "existing-token",
         "client_id": "environment-client-id",
         "redirect_uri": "http://localhost:8123/auth",
+        "future_field": "preserve-me",
     }
+
+
+def test_get_client_config_prefers_arguments_then_environment_then_document(
+    monkeypatch, tmp_path
+):
+    """Client settings should resolve in documented priority order."""
+    # Arrange: Store fallback settings and configure conflicting higher priorities.
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text(
+        '{"client_id": "saved-client", "redirect_uri": "http://saved"}',
+        encoding="utf-8",
+    )
+    args = Namespace(
+        client_id="argument-client",
+        redirect_uri=None,
+        token_file=token_file,
+    )
+    monkeypatch.setenv("VIESSMANN_CLIENT_ID", "environment-client")
+    monkeypatch.setenv("VIESSMANN_REDIRECT_URI", "http://environment")
+
+    # Act: Resolve the settings for a CLI invocation.
+    client_id, redirect_uri = get_client_config(args)
+
+    # Assert: Arguments override the environment, which overrides the document.
+    assert (client_id, redirect_uri) == ("argument-client", "http://environment")
+
+
+def test_get_client_config_uses_document_then_default_redirect(monkeypatch, tmp_path):
+    """Saved settings should supply the client ID and default redirect URI."""
+    # Arrange: Store only a saved client ID with no higher-priority settings.
+    token_file = tmp_path / "tokens.json"
+    token_file.write_text('{"client_id": "saved-client"}', encoding="utf-8")
+    args = Namespace(client_id=None, redirect_uri=None, token_file=token_file)
+    monkeypatch.delenv("VIESSMANN_CLIENT_ID", raising=False)
+    monkeypatch.delenv("VIESSMANN_REDIRECT_URI", raising=False)
+
+    # Act: Resolve settings for a command without arguments or environment values.
+    client_id, redirect_uri = get_client_config(args)
+
+    # Assert: The document supplies the client ID and the redirect falls back.
+    assert (client_id, redirect_uri) == ("saved-client", "http://localhost:4200/")
+
+
+@pytest.mark.asyncio
+async def test_async_main_rejects_malformed_credential_document(monkeypatch, tmp_path):
+    """Malformed credentials should produce a failing CLI status without rewrites."""
+    # Arrange: Point an initial login command at malformed credential data.
+    token_file = tmp_path / "tokens.json"
+    invalid_content = "{not-json"
+    token_file.write_text(invalid_content, encoding="utf-8")
+    monkeypatch.setattr(
+        "sys.argv", ["vi-client", "login", "--token-file", str(token_file)]
+    )
+
+    # Act: Invoke the command through its process-status boundary.
+    exit_status = await async_main()
+
+    # Assert: The command fails and leaves the malformed source untouched.
+    assert exit_status == 1
+    assert token_file.read_text(encoding="utf-8") == invalid_content
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_context.py
+++ b/tests/test_cli_context.py
@@ -83,14 +83,14 @@ async def test_cli_context_explicit_ids():
 
 
 @pytest.mark.asyncio
-async def test_cli_context_autodiscovery():
+async def test_cli_context_autodiscovery(tmp_path):
     """Test CLI context auto-discovery by mocking the Client completely."""
     # Arrange: Create mock client, device, and fixture data for test.
     args = Namespace(
         mock_device=None,
         client_id="test_id",
         redirect_uri="http://localhost",
-        token_file="tokens.json",
+        token_file=tmp_path / "tokens.json",
         insecure=False,
         installation_id=None,
         gateway_serial=None,
@@ -101,7 +101,6 @@ async def test_cli_context_autodiscovery():
     with (
         patch("vi_api_client.cli.ViClient") as MockClientCls,
         patch("vi_api_client.cli.OAuth"),
-        patch("vi_api_client.cli.load_config", return_value={}),
     ):
         # Setup the mock client instance
         mock_client = MockClientCls.return_value
@@ -139,13 +138,13 @@ async def test_cli_context_autodiscovery():
 
 
 @pytest.mark.asyncio
-async def test_cli_context_discovery_uses_provided_gateway_scope():
+async def test_cli_context_discovery_uses_provided_gateway_scope(tmp_path):
     """A supplied gateway serial should determine its missing installation ID."""
     args = Namespace(
         mock_device=None,
         client_id="test_id",
         redirect_uri="http://localhost",
-        token_file="tokens.json",
+        token_file=tmp_path / "tokens.json",
         insecure=False,
         installation_id=None,
         gateway_serial="GW-B",
@@ -155,7 +154,6 @@ async def test_cli_context_discovery_uses_provided_gateway_scope():
     with (
         patch("vi_api_client.cli.ViClient") as mock_client_cls,
         patch("vi_api_client.cli.OAuth"),
-        patch("vi_api_client.cli.load_config", return_value={}),
     ):
         mock_client = mock_client_cls.return_value
         mock_client.get_gateways = AsyncMock(
@@ -184,13 +182,13 @@ async def test_cli_context_discovery_uses_provided_gateway_scope():
 
 
 @pytest.mark.asyncio
-async def test_cli_context_discovery_uses_provided_installation_scope():
+async def test_cli_context_discovery_uses_provided_installation_scope(tmp_path):
     """A supplied installation ID should select one of its gateways."""
     args = Namespace(
         mock_device=None,
         client_id="test_id",
         redirect_uri="http://localhost",
-        token_file="tokens.json",
+        token_file=tmp_path / "tokens.json",
         insecure=False,
         installation_id="B",
         gateway_serial=None,
@@ -200,7 +198,6 @@ async def test_cli_context_discovery_uses_provided_installation_scope():
     with (
         patch("vi_api_client.cli.ViClient") as mock_client_cls,
         patch("vi_api_client.cli.OAuth"),
-        patch("vi_api_client.cli.load_config", return_value={}),
     ):
         mock_client = mock_client_cls.return_value
         mock_client.get_gateways = AsyncMock(
@@ -229,13 +226,13 @@ async def test_cli_context_discovery_uses_provided_installation_scope():
 
 
 @pytest.mark.asyncio
-async def test_cli_context_rejects_mismatched_partial_scope():
+async def test_cli_context_rejects_mismatched_partial_scope(tmp_path):
     """Partially specified IDs must not be combined across installations."""
     args = Namespace(
         mock_device=None,
         client_id="test_id",
         redirect_uri="http://localhost",
-        token_file="tokens.json",
+        token_file=tmp_path / "tokens.json",
         insecure=False,
         installation_id="A",
         gateway_serial="GW-B",
@@ -245,7 +242,6 @@ async def test_cli_context_rejects_mismatched_partial_scope():
     with (
         patch("vi_api_client.cli.ViClient") as mock_client_cls,
         patch("vi_api_client.cli.OAuth"),
-        patch("vi_api_client.cli.load_config", return_value={}),
     ):
         mock_client = mock_client_cls.return_value
         mock_client.get_gateways = AsyncMock(


### PR DESCRIPTION
Closes #47.\n\nRoutes CLI credential configuration through the shared credential document, removes the superseded CLI helpers, adds precedence and malformed-file CLI coverage, and documents malformed credential handling.\n\nValidation: python scripts/quality_check.py (Ruff, format, Pyright, 144 tests).