### PR TITLE
docs(agents): consolidate guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,12 +46,19 @@ Run `python -m build` as well when changing packaging metadata, build configurat
 
 After changes to architecture, public API, CLI behavior, dependencies, setup, tests or fixtures, CI, GitHub policy, or releases, check `README.md`, `docs/`, `CONTRIBUTING.md`, `AGENTS.md`, `pyproject.toml`, and relevant `.github/workflows/` files. Update affected documentation in the same change, or explicitly state that no update was needed.
 
-## Agent Skills
+## Agent skills
 
 ### Issue tracker
 
-Issues and specifications live in this repository's GitHub Issues. Write them in English, even when the surrounding conversation is in another language.
+Issues and specifications live in this repository's GitHub Issues and are
+written in English. See `docs/agents/issue-tracker.md`.
 
-### Domain documentation
+### Triage labels
 
-This repository uses a single-context domain-document layout. See `docs/adr/` and `CONTEXT.md` when the task concerns domain terminology or an architecture decision.
+The canonical triage labels use their default names. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repository uses a single-context domain-document layout. See
+`docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,42 @@
+# Domain Docs
+
+This repository uses a single-context domain-document layout.
+
+## Before exploring
+
+Read:
+
+- `CONTEXT.md` for the domain vocabulary.
+- Relevant ADRs under `docs/adr/`.
+
+If either location is absent, proceed silently. Domain documentation is created
+lazily when terminology or a durable architecture decision is resolved.
+
+## Layout
+
+```text
+/
+├── CONTEXT.md
+├── docs/
+│   ├── agents/
+│   │   ├── domain.md
+│   │   ├── issue-tracker.md
+│   │   └── triage-labels.md
+│   └── adr/
+└── src/
+```
+
+## Vocabulary
+
+Use canonical terms from `CONTEXT.md` in issue titles, specifications,
+architecture proposals, and test descriptions.
+
+Do not replace glossary terms with synonyms that `CONTEXT.md` explicitly
+avoids. If a required concept is absent, reconsider whether the term belongs to
+the domain or record the gap for domain modeling.
+
+## Architecture decisions
+
+Read ADRs relevant to the area being changed. If a proposal contradicts an
+accepted ADR, identify the conflict explicitly rather than silently overriding
+the decision.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,39 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all
+operations. Issue titles and bodies are written in English.
+
+## Repository
+
+Infer the repository from `git remote -v`. The configured remote is:
+
+`https://github.com/ignazhabibi/vi_api_client.git`
+
+## Conventions
+
+- Create issues with `gh issue create`.
+- Read issues and their comments with `gh issue view <number> --comments`.
+- List issues with `gh issue list` and request labels, bodies, and comments as
+  JSON when required.
+- Comment with `gh issue comment`.
+- Apply or remove labels with `gh issue edit`.
+- Close issues with `gh issue close`.
+
+## Pull requests as a triage surface
+
+PRs as a request surface: no.
+
+GitHub shares one number space across issues and pull requests. When a reference
+is ambiguous, resolve it as a pull request first and fall back to an issue.
+
+## Skill operations
+
+When a skill says "publish to the issue tracker," create a GitHub issue.
+
+When a skill says "fetch the relevant ticket," read the complete issue body,
+comments, and labels.
+
+Use GitHub native issue dependencies for blocking relationships when available.
+Otherwise, record blockers in the issue body as:
+
+`Blocked by: #<number>, #<number>`

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The engineering skills use five canonical triage roles. Each role maps directly
+to a GitHub label with the same name.
+
+| Canonical role    | GitHub label      | Meaning                                      |
+| ----------------- | ----------------- | -------------------------------------------- |
+| `needs-triage`    | `needs-triage`    | Maintainer needs to evaluate this issue      |
+| `needs-info`      | `needs-info`      | Waiting on the reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified and ready for an agent       |
+| `ready-for-human` | `ready-for-human` | Requires human implementation                |
+| `wontfix`         | `wontfix`         | Will not be actioned                         |
+
+When a skill refers to a canonical role, use the corresponding GitHub label
+from this table.


### PR DESCRIPTION
Consolidates repository-specific agent guidance into focused documents for GitHub issue tracking, triage labels, and domain documentation. Keeps AGENTS.md as concise pointers to the applicable guidance.\n\nValidation: python scripts/quality_check.py (Ruff, format, Pyright, 144 tests).