### PR TITLE
feat: add discovery adapters

### DIFF
--- a/src/vi_api_client/_discovery.py
+++ b/src/vi_api_client/_discovery.py
@@ -1,0 +1,34 @@
+"""Private adapters for installation and gateway discovery."""
+
+from typing import Any, Protocol
+
+from .connection import ViConnector
+from .const import ENDPOINT_GATEWAYS, ENDPOINT_INSTALLATIONS
+
+
+class _DiscoveryAdapter(Protocol):
+    """Retrieve raw discovery envelopes without constructing domain objects."""
+
+    async def get_installations(self) -> dict[str, Any]:
+        """Return the raw installations API envelope."""
+        raise NotImplementedError
+
+    async def get_gateways(self) -> dict[str, Any]:
+        """Return the raw gateways API envelope."""
+        raise NotImplementedError
+
+
+class _LiveDiscoveryAdapter:
+    """Retrieve discovery envelopes through the authenticated HTTP connector."""
+
+    def __init__(self, connector: ViConnector) -> None:
+        """Initialize the adapter with its authenticated connector."""
+        self._connector = connector
+
+    async def get_installations(self) -> dict[str, Any]:
+        """Return the raw installations API envelope."""
+        return await self._connector.get(ENDPOINT_INSTALLATIONS)
+
+    async def get_gateways(self) -> dict[str, Any]:
+        """Return the raw gateways API envelope."""
+        return await self._connector.get(ENDPOINT_GATEWAYS)

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -6,11 +6,11 @@ from dataclasses import replace
 from typing import Any
 from urllib.parse import unquote, urlsplit
 
+from ._discovery import _DiscoveryAdapter, _LiveDiscoveryAdapter
 from .auth import AbstractAuth
 from .connection import ViConnector
 from .const import (
     ENDPOINT_FEATURES,
-    ENDPOINT_GATEWAYS,
     ENDPOINT_INSTALLATIONS,
 )
 from .exceptions import ViError, ViResponseError, ViValidationError
@@ -42,6 +42,9 @@ class ViClient:
             auth: Authentication handler providing the access token.
         """
         self.connector = ViConnector(auth)
+        self._discovery_adapter: _DiscoveryAdapter = _LiveDiscoveryAdapter(
+            self.connector
+        )
 
     async def get_installations(self) -> list[Installation]:
         """Get list of installations.
@@ -50,10 +53,12 @@ class ViClient:
             List of Installation objects available to the user.
         """
         _LOGGER.debug("Fetching installations...")
-        installations_data = await self.connector.get(ENDPOINT_INSTALLATIONS)
+        installations_data = await self._discovery_adapter.get_installations()
         installations = [
             Installation.from_api(installation_data)
-            for installation_data in installations_data.get("data", [])
+            for installation_data in self._get_discovery_data(
+                installations_data, "Installation"
+            )
         ]
         _LOGGER.debug("Found %s installations", len(installations))
         return installations
@@ -65,10 +70,10 @@ class ViClient:
             List of Gateway objects found (across all installations).
         """
         _LOGGER.debug("Fetching gateways...")
-        gateways_data = await self.connector.get(ENDPOINT_GATEWAYS)
+        gateways_data = await self._discovery_adapter.get_gateways()
         gateways = [
             Gateway.from_api(gateway_data)
-            for gateway_data in gateways_data.get("data", [])
+            for gateway_data in self._get_discovery_data(gateways_data, "Gateway")
         ]
         _LOGGER.debug("Found %s gateways", len(gateways))
         return gateways
@@ -327,6 +332,20 @@ class ViClient:
     # ------------------------------------------------------------------
     # Private Helper Methods
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_discovery_data(
+        envelope: object, resource_name: str
+    ) -> list[dict[str, Any]]:
+        """Validate and return the data collection from a discovery envelope."""
+        if not isinstance(envelope, dict):
+            raise ViResponseError(f"{resource_name} response must be an object")
+        data = envelope.get("data")
+        if not isinstance(data, list) or not all(
+            isinstance(item, dict) for item in data
+        ):
+            raise ViResponseError(f"{resource_name} response data must be a list")
+        return data
 
     async def _execute_command(
         self, control: FeatureControl, payload: dict[str, Any]

--- a/src/vi_api_client/connection.py
+++ b/src/vi_api_client/connection.py
@@ -3,6 +3,8 @@
 import logging
 from typing import Any
 
+import aiohttp
+
 from .auth import AbstractAuth
 from .const import API_BASE_URL
 from .exceptions import (
@@ -10,6 +12,7 @@ from .exceptions import (
     ViError,
     ViNotFoundError,
     ViRateLimitError,
+    ViResponseError,
     ViServerInternalError,
     ViValidationError,
 )
@@ -114,8 +117,10 @@ class ViConnector:
             # Verify response status and raise exceptions if needed.
             await _raise_for_status(response)
 
-            # Return parsed JSON for success.
+            # Successful API responses must still satisfy the JSON contract.
             try:
                 return await response.json()
-            except Exception:
-                return {}
+            except (aiohttp.ClientError, ValueError) as error:
+                raise ViResponseError(
+                    "Successful API response was not valid JSON"
+                ) from error

--- a/src/vi_api_client/fixtures/discovery.json
+++ b/src/vi_api_client/fixtures/discovery.json
@@ -1,0 +1,24 @@
+{
+  "installations": {
+    "data": [
+      {
+        "id": "99999",
+        "description": "Mock Installation ({device_name})",
+        "alias": "Mock Home",
+        "address": {
+          "city": "Mock City"
+        }
+      }
+    ]
+  },
+  "gateways": {
+    "data": [
+      {
+        "serial": "MOCK_GATEWAY_SERIAL",
+        "version": "1.0.0",
+        "status": "connected",
+        "installationId": "99999"
+      }
+    ]
+  }
+}

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -1,8 +1,9 @@
 import json
 from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from ._discovery import _DiscoveryAdapter
 from .api import ViClient
 from .auth import AbstractAuth
 from .models import (
@@ -10,24 +11,33 @@ from .models import (
     Device,
     Feature,
     FeatureControl,
-    Gateway,
     GatewayDeviceRefreshResult,
-    Installation,
 )
 from .parsing import parse_feature_flat
 
 
-class MockAuth(AbstractAuth):
-    """Mock authentication provider."""
+class _FixtureDiscoveryAdapter:
+    """Return deterministic discovery envelopes without authentication or HTTP."""
 
-    async def async_get_access_token(self) -> str:
-        """Return a mock access token."""
-        return "mock_token"
+    def __init__(self, device_name: str) -> None:
+        """Initialize the adapter for a selected fixture device."""
+        self._device_name = device_name
+        fixture_path = Path(__file__).parent / "fixtures" / "discovery.json"
+        with fixture_path.open(encoding="utf-8") as file:
+            self._data = cast(dict[str, dict[str, Any]], json.load(file))
 
-    def __init__(self, websession: Any = None) -> None:
-        """Initialize mock auth."""
-        # Standard AbstractAuth expects a websession, but we don't use it in Mock
-        super().__init__(websession)
+    async def get_installations(self) -> dict[str, Any]:
+        """Return the mock installation envelope."""
+        envelope = self._data["installations"]
+        installation = envelope["data"][0]
+        installation["description"] = installation["description"].format(
+            device_name=self._device_name
+        )
+        return envelope
+
+    async def get_gateways(self) -> dict[str, Any]:
+        """Return the mock gateway envelope."""
+        return self._data["gateways"]
 
 
 # Mapping of fixture names to device types
@@ -58,12 +68,12 @@ class MockViClient(ViClient):
         Args:
             device_name: The name of the mock device (e.g. "Vitodens200W").
                 Must correspond to a file in the fixtures directory.
-            auth: Optional auth provider (not used for logic,
-                but kept for interface compatibility).
+            auth: Ignored compatibility argument; mock clients do not authenticate.
         """
-        # Pass dummy auth if none provided, to satisfy superclass
-        super().__init__(auth or MockAuth())
         self.device_name = device_name
+        self._discovery_adapter: _DiscoveryAdapter = _FixtureDiscoveryAdapter(
+            device_name
+        )
         self._data_cache = None
 
     @staticmethod
@@ -73,7 +83,11 @@ class MockViClient(ViClient):
         if not fixtures_dir.exists():
             return []
 
-        return sorted(file.stem for file in fixtures_dir.glob("*.json"))
+        return sorted(
+            file.stem
+            for file in fixtures_dir.glob("*.json")
+            if file.stem != "discovery"
+        )
 
     def _load_data(self) -> dict[str, Any]:
         """Load the JSON data for the selected device.
@@ -100,28 +114,6 @@ class MockViClient(ViClient):
             self._data_cache = json.load(file)
 
         return self._data_cache
-
-    async def get_installations(self) -> list[Installation]:
-        """Return a mock installation."""
-        return [
-            Installation(
-                id="99999",
-                description=f"Mock Installation ({self.device_name})",
-                alias="Mock Home",
-                address={"city": "Mock City"},
-            )
-        ]
-
-    async def get_gateways(self) -> list[Gateway]:
-        """Return a mock gateway."""
-        return [
-            Gateway(
-                serial="MOCK_GATEWAY_SERIAL",
-                version="1.0.0",
-                status="connected",
-                installation_id="99999",
-            )
-        ]
 
     async def get_devices(
         self,

--- a/tests/integration/test_workflow_mock.py
+++ b/tests/integration/test_workflow_mock.py
@@ -1,11 +1,28 @@
 """Integration tests for the full workflow using Mock Client."""
 
-from unittest.mock import AsyncMock
-
 import pytest
 
 from vi_api_client import MockViClient
 from vi_api_client.models import Device
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mock_discovery_uses_shared_domain_conversion_without_auth():
+    """Mock discovery should share client conversion without a live connector."""
+    # Arrange: Use a fixture-backed client with no auth or HTTP dependencies.
+    client = MockViClient("Vitodens200W")
+
+    # Act: Discover installations and gateways through the inherited workflow.
+    installations = await client.get_installations()
+    gateways = await client.get_gateways()
+
+    # Assert: Fixture envelopes are converted by the shared client implementation.
+    assert installations[0].id == "99999"
+    assert installations[0].description == "Mock Installation (Vitodens200W)"
+    assert gateways[0].serial == "MOCK_GATEWAY_SERIAL"
+    assert gateways[0].installation_id == installations[0].id
+    assert not hasattr(client, "connector")
 
 
 @pytest.mark.integration
@@ -111,10 +128,9 @@ async def test_mock_workflow_vitocal():
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_mock_set_feature_stays_offline():
-    """Verify mock writes use simulated execution instead of the connector."""
-    # Arrange: Hydrate a mock heat pump and guard against connector POST requests.
+    """Verify mock writes use simulated execution without live resources."""
+    # Arrange: Hydrate a mock heat pump without authentication or HTTP resources.
     client = MockViClient("Vitocal250A")
-    client.connector.post = AsyncMock()
     device = (
         await client.get_devices(
             installation_id="99999",
@@ -128,9 +144,8 @@ async def test_mock_set_feature_stays_offline():
     # Act: Set the writable slope through the standard high-level client method.
     response, updated_device = await client.set_feature(device, slope, 0.7)
 
-    # Assert: The command should succeed locally without invoking the connector.
+    # Assert: The command should succeed locally.
     updated_slope = updated_device.get_feature(slope.name)
-    client.connector.post.assert_not_awaited()
     assert response.success is True
     assert updated_slope is not None
     assert updated_slope.value == 0.7
@@ -170,7 +185,6 @@ async def test_mock_gateway_device_refresh_stays_offline():
     """Verify gateway-scoped refresh has offline mock parity."""
     # Arrange: Use two known devices on the same mock gateway.
     client = MockViClient("Vitodens200W")
-    client.connector.post = AsyncMock()
     devices = [
         Device(
             id=device_id,
@@ -187,7 +201,6 @@ async def test_mock_gateway_device_refresh_stays_offline():
     result = await client.update_gateway_devices(devices)
 
     # Assert: Mock refresh preserves order and metadata without HTTP access.
-    client.connector.post.assert_not_awaited()
     assert result.is_complete
     assert [device.id for device in result.updated_devices] == ["10", "0"]
     assert [device.model_id for device in result.updated_devices] == [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -444,6 +444,72 @@ async def test_get_gateways(load_fixture_json):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "method"),
+    [
+        (ENDPOINT_INSTALLATIONS, "get_installations"),
+        (ENDPOINT_GATEWAYS, "get_gateways"),
+    ],
+)
+async def test_discovery_rejects_successful_non_json_responses(endpoint, method):
+    """Discovery should reject successful responses that are not JSON objects."""
+    # Arrange: Return non-JSON content from each discovery endpoint.
+    url = f"{API_BASE_URL}{endpoint}"
+
+    with aioresponses() as mock_responses:
+        mock_responses.get(url, body="not JSON", content_type="text/plain")
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: The public response error communicates the contract failure.
+            with pytest.raises(ViResponseError):
+                await getattr(client, method)()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "method"),
+    [
+        (ENDPOINT_INSTALLATIONS, "get_installations"),
+        (ENDPOINT_GATEWAYS, "get_gateways"),
+    ],
+)
+async def test_discovery_rejects_successful_malformed_json_envelopes(endpoint, method):
+    """Discovery should reject successful JSON that violates its envelope contract."""
+    # Arrange: Return a JSON object whose data member is not a collection.
+    url = f"{API_BASE_URL}{endpoint}"
+
+    with aioresponses() as mock_responses:
+        mock_responses.get(url, payload={"data": {}})
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: The public response error communicates the contract failure.
+            with pytest.raises(ViResponseError):
+                await getattr(client, method)()
+
+
+@pytest.mark.asyncio
+async def test_discovery_keeps_a_caller_managed_session_open(load_fixture_json):
+    """Discovery must not close a session supplied through authentication."""
+    # Arrange: Provide a caller-owned session and successful installation envelope.
+    url = f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}"
+    with aioresponses() as mock_responses:
+        mock_responses.get(url, payload=load_fixture_json("installations.json"))
+        session = aiohttp.ClientSession()
+        try:
+            client = ViClient(MockAuth(session))
+
+            # Act: Run discovery through the adapter-backed client.
+            await client.get_installations()
+
+            # Assert: The client did not create or close a replacement session.
+            assert not session.closed
+        finally:
+            await session.close()
+
+
+@pytest.mark.asyncio
 async def test_get_full_installation_status_uses_matching_gateways_only():
     """Full status should not query gateways from other installations."""
     # Arrange: Mock one gateway for each of two installations.

--- a/tests/test_mock_data_integrity.py
+++ b/tests/test_mock_data_integrity.py
@@ -21,7 +21,11 @@ MOCK_DATA_DIR = os.path.join(
 
 def get_mock_data_files():
     """Get all bundled mock device JSON files."""
-    return sorted(glob.glob(os.path.join(MOCK_DATA_DIR, "*.json")))
+    return sorted(
+        file_path
+        for file_path in glob.glob(os.path.join(MOCK_DATA_DIR, "*.json"))
+        if not file_path.endswith("discovery.json")
+    )
 
 
 @pytest.mark.parametrize("file_path", get_mock_data_files(), ids=os.path.basename)


### PR DESCRIPTION
## Summary
- add private live and fixture adapters for installation and gateway discovery
- share domain conversion between live and fixture client workflows
- raise ViResponseError for successful malformed or non-JSON discovery responses

## Validation
- ruff check .
- ruff format --check .
- pyright --pythonpath .venv/bin/python (changed files)
- python -m pytest -q

Closes #52