### PR TITLE
Unify fixture and live feature hydration

### DIFF
--- a/src/vi_api_client/_discovery.py
+++ b/src/vi_api_client/_discovery.py
@@ -3,11 +3,12 @@
 from typing import Any, Protocol
 
 from .connection import ViConnector
-from .const import ENDPOINT_GATEWAYS, ENDPOINT_INSTALLATIONS
+from .const import ENDPOINT_FEATURES, ENDPOINT_GATEWAYS, ENDPOINT_INSTALLATIONS
+from .models import Device
 
 
 class _DiscoveryAdapter(Protocol):
-    """Retrieve raw discovery envelopes without constructing domain objects."""
+    """Retrieve raw client envelopes without constructing domain objects."""
 
     async def get_installations(self) -> dict[str, Any]:
         """Return the raw installations API envelope."""
@@ -17,9 +18,21 @@ class _DiscoveryAdapter(Protocol):
         """Return the raw gateways API envelope."""
         raise NotImplementedError
 
+    async def get_devices(
+        self, installation_id: str, gateway_serial: str
+    ) -> dict[str, Any]:
+        """Return the raw devices API envelope."""
+        raise NotImplementedError
+
+    async def get_features(
+        self, device: Device, payload: dict[str, bool | list[str]]
+    ) -> dict[str, Any]:
+        """Return the raw feature API envelope."""
+        raise NotImplementedError
+
 
 class _LiveDiscoveryAdapter:
-    """Retrieve discovery envelopes through the authenticated HTTP connector."""
+    """Retrieve client envelopes through the authenticated HTTP connector."""
 
     def __init__(self, connector: ViConnector) -> None:
         """Initialize the adapter with its authenticated connector."""
@@ -32,3 +45,23 @@ class _LiveDiscoveryAdapter:
     async def get_gateways(self) -> dict[str, Any]:
         """Return the raw gateways API envelope."""
         return await self._connector.get(ENDPOINT_GATEWAYS)
+
+    async def get_devices(
+        self, installation_id: str, gateway_serial: str
+    ) -> dict[str, Any]:
+        """Return the raw devices API envelope."""
+        url = (
+            f"{ENDPOINT_INSTALLATIONS}/{installation_id}/gateways/"
+            f"{gateway_serial}/devices"
+        )
+        return await self._connector.get(url)
+
+    async def get_features(
+        self, device: Device, payload: dict[str, bool | list[str]]
+    ) -> dict[str, Any]:
+        """Return the raw feature API envelope."""
+        url = (
+            f"{ENDPOINT_FEATURES}/{device.installation_id}/gateways/"
+            f"{device.gateway_serial}/devices/{device.id}/features/filter"
+        )
+        return await self._connector.post(url, payload)

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -9,10 +9,7 @@ from urllib.parse import unquote, urlsplit
 from ._discovery import _DiscoveryAdapter, _LiveDiscoveryAdapter
 from .auth import AbstractAuth
 from .connection import ViConnector
-from .const import (
-    ENDPOINT_FEATURES,
-    ENDPOINT_INSTALLATIONS,
-)
+from .const import ENDPOINT_FEATURES
 from .exceptions import ViError, ViResponseError, ViValidationError
 from .models import (
     CommandResponse,
@@ -96,8 +93,9 @@ class ViClient:
         Returns:
             List of Device objects (populated with features if requested).
         """
-        url = self._build_devices_url(installation_id, gateway_serial)
-        devices_data = await self.connector.get(url)
+        devices_data = await self._discovery_adapter.get_devices(
+            installation_id, gateway_serial
+        )
         devices = [
             Device.from_api(device_data, gateway_serial, installation_id)
             for device_data in devices_data.get("data", [])
@@ -135,7 +133,6 @@ class ViClient:
         Returns:
             List of Feature objects (flattened).
         """
-        url = self._build_features_url(device)
         payload: dict[str, bool | list[str]] = {
             "skipDisabled": only_enabled,
             "skipNotReady": only_enabled,
@@ -148,19 +145,26 @@ class ViClient:
             device.id,
             only_enabled,
         )
-        response = await self.connector.post(url, payload)
+        response = await self._discovery_adapter.get_features(device, payload)
         raw_features = response.get("data", [])
 
         flat_features = []
         for raw_feature in raw_features:
             flat_features.extend(parse_feature_flat(raw_feature))
 
+        filtered_features = [
+            feature
+            for feature in flat_features
+            if (not only_enabled or (feature.is_enabled and feature.is_ready))
+            and (not feature_names or feature.name in feature_names)
+        ]
+
         _LOGGER.debug(
             "Fetched %s raw objects -> %s flat features",
             len(raw_features),
-            len(flat_features),
+            len(filtered_features),
         )
-        return flat_features
+        return filtered_features
 
     async def get_full_installation_status(
         self, installation_id: str, only_enabled: bool = True
@@ -364,23 +368,6 @@ class ViClient:
         """
         response_data = await self.connector.post(control.uri, payload)
         return CommandResponse.from_api(response_data)
-
-    def _build_devices_url(self, installation_id: str, gateway_serial: str) -> str:
-        return (
-            f"{ENDPOINT_INSTALLATIONS}/{installation_id}/gateways/"
-            f"{gateway_serial}/devices"
-        )
-
-    def _build_features_url(
-        self, device: Device, feature_name: str | None = None
-    ) -> str:
-        base = (
-            f"{ENDPOINT_FEATURES}/{device.installation_id}/gateways/"
-            f"{device.gateway_serial}/devices/{device.id}/features"
-        )
-        if feature_name:
-            return f"{base}/{feature_name}"
-        return f"{base}/filter"
 
     @staticmethod
     def _validate_gateway_devices(devices: list[Device]) -> None:

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -9,35 +9,69 @@ from .auth import AbstractAuth
 from .models import (
     CommandResponse,
     Device,
-    Feature,
     FeatureControl,
     GatewayDeviceRefreshResult,
 )
-from .parsing import parse_feature_flat
 
 
 class _FixtureDiscoveryAdapter:
-    """Return deterministic discovery envelopes without authentication or HTTP."""
+    """Return deterministic client envelopes without authentication or HTTP."""
 
     def __init__(self, device_name: str) -> None:
         """Initialize the adapter for a selected fixture device."""
         self._device_name = device_name
         fixture_path = Path(__file__).parent / "fixtures" / "discovery.json"
         with fixture_path.open(encoding="utf-8") as file:
-            self._data = cast(dict[str, dict[str, Any]], json.load(file))
+            self._discovery_data = cast(dict[str, dict[str, Any]], json.load(file))
+        self._feature_data: dict[str, Any] | None = None
 
     async def get_installations(self) -> dict[str, Any]:
         """Return the mock installation envelope."""
-        envelope = self._data["installations"]
-        installation = envelope["data"][0]
-        installation["description"] = installation["description"].format(
-            device_name=self._device_name
-        )
-        return envelope
+        return {
+            "data": [
+                {
+                    **self._discovery_data["installations"]["data"][0],
+                    "description": self._discovery_data["installations"]["data"][0][
+                        "description"
+                    ].format(device_name=self._device_name),
+                }
+            ]
+        }
 
     async def get_gateways(self) -> dict[str, Any]:
         """Return the mock gateway envelope."""
-        return self._data["gateways"]
+        return self._discovery_data["gateways"]
+
+    async def get_devices(
+        self, installation_id: str, gateway_serial: str
+    ) -> dict[str, Any]:
+        """Return the selected fixture as one deterministic device."""
+        return {
+            "data": [
+                {
+                    "id": "0",
+                    "modelId": self._device_name,
+                    "deviceType": DEVICE_TYPE_MAP.get(self._device_name, "heating"),
+                    "status": "connected",
+                }
+            ]
+        }
+
+    async def get_features(
+        self, device: Device, payload: dict[str, bool | list[str]]
+    ) -> dict[str, Any]:
+        """Return the selected fixture's raw feature envelope."""
+        return self._load_feature_data()
+
+    def _load_feature_data(self) -> dict[str, Any]:
+        """Load the selected fixture feature envelope once."""
+        if self._feature_data is None:
+            fixture_path = (
+                Path(__file__).parent / "fixtures" / f"{self._device_name}.json"
+            )
+            with fixture_path.open(encoding="utf-8") as file:
+                self._feature_data = cast(dict[str, Any], json.load(file))
+        return self._feature_data
 
 
 # Mapping of fixture names to device types
@@ -74,7 +108,6 @@ class MockViClient(ViClient):
         self._discovery_adapter: _DiscoveryAdapter = _FixtureDiscoveryAdapter(
             device_name
         )
-        self._data_cache = None
 
     @staticmethod
     def get_available_mock_devices() -> list[str]:
@@ -88,95 +121,6 @@ class MockViClient(ViClient):
             for file in fixtures_dir.glob("*.json")
             if file.stem != "discovery"
         )
-
-    def _load_data(self) -> dict[str, Any]:
-        """Load the JSON data for the selected device.
-
-        Returns:
-            The parsed JSON data as a dictionary.
-
-        Raises:
-            FileNotFoundError: If the fixture file does not exist.
-        """
-        if self._data_cache:
-            return self._data_cache
-
-        fixtures_dir = Path(__file__).parent / "fixtures"
-        file_path = fixtures_dir / f"{self.device_name}.json"
-
-        if not file_path.exists():
-            raise FileNotFoundError(
-                f"Mock device file not found: {self.device_name}.json. "
-                f"Available: {self.get_available_mock_devices()}"
-            )
-
-        with file_path.open(encoding="utf-8") as file:
-            self._data_cache = json.load(file)
-
-        return self._data_cache
-
-    async def get_devices(
-        self,
-        installation_id: str,
-        gateway_serial: str,
-        include_features: bool = False,
-        only_active_features: bool = False,
-    ) -> list[Device]:
-        """Return the mocked device as a typed model."""
-        device = Device(
-            id="0",
-            gateway_serial=gateway_serial,
-            installation_id=installation_id,
-            model_id=self.device_name,
-            device_type=DEVICE_TYPE_MAP.get(self.device_name, "heating"),
-            status="connected",
-        )
-
-        if include_features:
-            features = await self.get_features(
-                device, only_enabled=only_active_features
-            )
-            device = replace(device, features=features)
-
-        return [device]
-
-    async def get_features(
-        self,
-        device: Device,
-        only_enabled: bool = False,
-        feature_names: list[str] | None = None,
-    ) -> list[Feature]:
-        """Return the list of features from the loaded JSON file.
-
-        Args:
-            device: The device object (context).
-            only_enabled: If True, only return enabled features.
-            feature_names: Optional whitelist of feature names.
-
-        Returns:
-            List of flattened Feature objects.
-        """
-        data = self._load_data()
-        raw_features = data.get("data", [])
-
-        # Parse ALL features to flat list
-        all_features = []
-        for raw_feature in raw_features:
-            all_features.extend(parse_feature_flat(raw_feature))
-
-        # Filter
-        filtered = []
-        for feature in all_features:
-            if only_enabled and not feature.is_enabled:
-                continue
-
-            # Strict name matching (assuming feature_names are flat names)
-            if feature_names and feature.name not in feature_names:
-                continue
-
-            filtered.append(feature)
-
-        return filtered
 
     async def update_gateway_devices(
         self, devices: list[Device]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Tests for vitoclient.api module (Flat Architecture)."""
 
 import re
+from copy import deepcopy
 from dataclasses import replace
 
 import aiohttp
@@ -615,6 +616,45 @@ async def test_get_features(load_fixture_json):
             assert features[0].name == "heating.sensors.temperature.outside"
             assert features[0].value == 5.5
             assert features[1].name == "heating.circuits.0.active"
+
+
+@pytest.mark.asyncio
+async def test_get_features_applies_enabled_ready_and_name_filters_after_response(
+    load_fixture_json,
+):
+    """Live feature filtering should not rely only on server-side filter hints."""
+    # Arrange: Return requested, disabled, and not-ready features despite filter hints.
+    data = deepcopy(load_fixture_json("features_heating_sensors.json"))
+    data["data"][0]["isEnabled"] = False
+    not_ready_feature = deepcopy(data["data"][1])
+    not_ready_feature["feature"] = "test.notReady"
+    not_ready_feature["isEnabled"] = True
+    not_ready_feature["isReady"] = False
+    data["data"].append(not_ready_feature)
+    device = Device(
+        id="0",
+        gateway_serial="1234567890",
+        installation_id="123456",
+        model_id="test",
+        device_type="heating",
+        status="ok",
+    )
+    url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/123456/gateways/1234567890/devices/0/features/filter"
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload=data)
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act: Ask for a specific enabled and ready feature.
+            features = await client.get_features(
+                device,
+                only_enabled=True,
+                feature_names=["heating.circuits.0.active", "test.notReady.active"],
+            )
+
+    # Assert: Client-side filtering enforces the public semantics.
+    assert [feature.name for feature in features] == ["heating.circuits.0.active"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -1,0 +1,60 @@
+"""Public workflow tests for the fixture-backed client."""
+
+import pytest
+
+from vi_api_client import MockViClient
+
+
+@pytest.mark.asyncio
+async def test_mock_device_hydration_uses_deterministic_fixture_topology():
+    """Mock device discovery should use the selected fixture in one topology."""
+    # Arrange: Select a known fixture device.
+    client = MockViClient("Vitodens200W")
+
+    # Act: Discover and hydrate through the public client workflow.
+    devices = await client.get_devices(
+        "99999", "MOCK_GATEWAY_SERIAL", include_features=True
+    )
+
+    # Assert: The public mock represents exactly its selected fixture device.
+    assert len(devices) == 1
+    assert devices[0].id == "0"
+    assert devices[0].model_id == "Vitodens200W"
+    assert devices[0].features
+
+
+@pytest.mark.asyncio
+async def test_mock_update_device_returns_hydrated_copy_without_mutating_input():
+    """Mock refresh should have the same immutable public contract as live refresh."""
+    # Arrange: Discover an unhydrated fixture device.
+    client = MockViClient("Vitodens200W")
+    device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
+
+    # Act: Refresh through the public client workflow.
+    refreshed_device = await client.update_device(device)
+
+    # Assert: The input remains unhydrated and the returned copy has features.
+    assert device.features == []
+    assert refreshed_device is not device
+    assert refreshed_device.features
+
+
+@pytest.mark.asyncio
+async def test_mock_feature_filters_apply_shared_enabled_and_name_semantics():
+    """Mock filtering should retain only requested enabled and ready features."""
+    # Arrange: Select a fixture that includes disabled features.
+    client = MockViClient("Vitocal200S")
+    device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
+
+    # Act: Request enabled and ready features by explicit names.
+    features = await client.get_features(
+        device,
+        only_enabled=True,
+        feature_names=[
+            "heating.burners.0",
+            "device.serial",
+        ],
+    )
+
+    # Assert: Shared filtering retains the requested enabled and ready feature only.
+    assert [feature.name for feature in features] == ["device.serial"]


### PR DESCRIPTION
Closes #53

## Summary

- Route device and feature envelopes through shared live/fixture adapters
- Centralize feature parsing, filtering, hydration, and immutable refresh behavior
- Add live and fixture parity coverage

## Validation

- `python -m build`
- `ruff check .`
- `ruff format --check .`
- `pytest -q`