### PR TITLE
feat: add client command execution

### DIFF
--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -122,6 +122,20 @@ if response.success:
     response, device = await client.set_feature(device, shift_feature, 7.0)
 ```
 
+### `execute_command(feature: Feature, parameters: dict[str, Any]) -> CommandResponse`
+
+Executes an explicit command parameter set for a writable feature. Unlike
+`set_feature`, this operation does not resolve dependencies, validate against
+the feature's single-value constraints, or update a `Device`: every supplied
+parameter is sent unchanged.
+
+Use it only when the caller already has the complete command payload, such as
+an advanced integration writing both heating-curve values at once.
+
+```python
+response = await client.execute_command(slope_feature, {"slope": 0.7, "shift": 7.0})
+```
+
 ## Next Steps
 
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.

--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -91,6 +91,10 @@ If you need to execute a command with multiple parameters at once (rare), you ca
 vi-client exec heating.circuits.0.heating.curve setCurve slope=1.4 shift=0
 ```
 
+`exec` sends every supplied parameter as one explicit command. It does not add
+dependent values or optimistically update a device; use `set` for the normal
+single-feature workflow.
+
 ## 8. Mock Devices (Offline Mode)
 The client includes sample data for various devices, allowing you to test integration logic without a real account.
 Mock mode does not read OAuth credentials or `tokens.json` and never makes network

--- a/src/vi_api_client/_commands.py
+++ b/src/vi_api_client/_commands.py
@@ -1,0 +1,30 @@
+"""Private adapters for feature command execution."""
+
+from typing import Any, Protocol
+
+from .connection import ViConnector
+from .models import FeatureControl
+
+
+class _CommandAdapter(Protocol):
+    """Execute feature commands without constructing domain objects."""
+
+    async def execute_command(
+        self, control: FeatureControl, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return the raw command response envelope."""
+        raise NotImplementedError
+
+
+class _LiveCommandAdapter:
+    """Execute feature commands through the authenticated HTTP connector."""
+
+    def __init__(self, connector: ViConnector) -> None:
+        """Initialize the adapter with its authenticated connector."""
+        self._connector = connector
+
+    async def execute_command(
+        self, control: FeatureControl, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return the raw command response envelope."""
+        return await self._connector.post(control.uri, parameters)

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from typing import Any
 from urllib.parse import unquote, urlsplit
 
+from ._commands import _CommandAdapter, _LiveCommandAdapter
 from ._discovery import _DiscoveryAdapter, _LiveDiscoveryAdapter
 from .auth import AbstractAuth
 from .connection import ViConnector
@@ -42,6 +43,7 @@ class ViClient:
         self._discovery_adapter: _DiscoveryAdapter = _LiveDiscoveryAdapter(
             self.connector
         )
+        self._command_adapter: _CommandAdapter = _LiveCommandAdapter(self.connector)
 
     async def get_installations(self) -> list[Installation]:
         """Get list of installations.
@@ -297,10 +299,11 @@ class ViClient:
         Raises:
             ValueError: If feature is read-only or value is out of bounds.
         """
-        if not feature.control:
+        if not feature.is_writable:
             raise ValueError(f"Feature '{feature.name}' is read-only.")
 
         control = feature.control
+        assert control is not None
         _LOGGER.debug(
             "Setting %s to %s via %s",
             feature.name,
@@ -333,6 +336,29 @@ class ViClient:
         # Return unchanged device on failure
         return response, device
 
+    async def execute_command(
+        self, feature: Feature, parameters: dict[str, Any]
+    ) -> CommandResponse:
+        """Execute an explicit feature command without changing its parameters.
+
+        Args:
+            feature: A writable feature that identifies the command endpoint.
+            parameters: Complete command parameters to send exactly as supplied.
+
+        Returns:
+            The command response from the API.
+
+        Raises:
+            ValueError: If the feature is read-only.
+        """
+        if not feature.is_writable:
+            raise ValueError(f"Feature '{feature.name}' is read-only.")
+
+        control = feature.control
+        assert control is not None
+        _LOGGER.debug("Executing %s for %s", control.command_name, feature.name)
+        return await self._execute_command(control, parameters)
+
     # ------------------------------------------------------------------
     # Private Helper Methods
     # ------------------------------------------------------------------
@@ -354,19 +380,21 @@ class ViClient:
     async def _execute_command(
         self, control: FeatureControl, payload: dict[str, Any]
     ) -> CommandResponse:
-        """Execute a feature command through the live API connector.
-
-        Subclasses can override this boundary to provide alternative command
-        execution without changing validation or optimistic device updates.
+        """Execute a feature command through the configured command adapter.
 
         Args:
             control: The feature control describing the command endpoint.
-            payload: The resolved command parameters.
+            payload: The command parameters to send.
 
         Returns:
             The parsed command response.
         """
-        response_data = await self.connector.post(control.uri, payload)
+        response_data = await self._command_adapter.execute_command(control, payload)
+        if not isinstance(response_data, dict):
+            raise ViResponseError("Command response must be an object")
+        response = response_data.get("data", response_data)
+        if not isinstance(response, dict):
+            raise ViResponseError("Command response data must be an object")
         return CommandResponse.from_api(response_data)
 
     @staticmethod

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -8,7 +8,7 @@ import math
 import os
 import sys
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
@@ -515,16 +515,19 @@ async def cmd_exec(args) -> bool:  # noqa: PLR0911
             target = await _fetch_target_feature(ctx, args.feature_name)
             if target is None:
                 return False
-            device, feature = target
+            _device, feature = target
 
-            if not feature.control:
+            if not feature.is_writable:
                 print(f"Error: Feature '{feature.name}' is read-only (no control).")
                 return False
 
+            control = feature.control
+            assert control is not None
+
             # 3. Validate Command Name
-            if feature.control.command_name != args.command_name:
+            if control.command_name != args.command_name:
                 print(
-                    f"Warning: Feature expects command '{feature.control.command_name}'"
+                    f"Warning: Feature expects command '{control.command_name}'"
                     f", but you specified '{args.command_name}'."
                 )
                 print("Error: Features only expose their primary control command.")
@@ -532,23 +535,9 @@ async def cmd_exec(args) -> bool:  # noqa: PLR0911
 
             print(f"Executing '{args.command_name}' on {feature.name}...")
 
-            # 4. Determine Value
-            target_val = _determine_target_value(args.params, params_dict, feature)
-
-            # 5. Execute
-            if target_val is not None:
-                print(f"Using high-level set_feature(target={target_val})...")
-                result, _updated_device = await ctx.client.set_feature(
-                    device,
-                    feature,
-                    target_val,
-                )
-            else:
-                print(f"Using low-level POST with params: {params_dict}")
-                result = await ctx.client.connector.post(
-                    feature.control.uri, params_dict
-                )
-                result = CommandResponse.from_api(result)
+            # 4. Execute the explicitly supplied parameter set unchanged.
+            print(f"Using execute_command with params: {params_dict}")
+            result = await ctx.client.execute_command(feature, params_dict)
 
             return _print_command_result(result)
 
@@ -587,25 +576,6 @@ def _transient_device(ctx: CLIContext) -> Device:
         device_type="unknown",
         status="online",
     )
-
-
-def _determine_target_value(
-    raw_params: list[str], params_dict: dict[str, Any], feature: Any
-) -> Any | None:
-    """Determine the target value from CLI params."""
-    # Try from dict
-    val = params_dict.get(feature.control.param_name)
-    if val is not None:
-        return val
-
-    # Try raw scalar
-    if raw_params and len(raw_params) == 1 and "=" not in raw_params[0]:
-        raw_arg = raw_params[0]
-        with suppress(ValueError):
-            return float(raw_arg)
-        return raw_arg
-
-    return None
 
 
 def _print_command_result(result: CommandResponse) -> bool:

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -3,11 +3,11 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
+from ._commands import _CommandAdapter
 from ._discovery import _DiscoveryAdapter
 from .api import ViClient
 from .auth import AbstractAuth
 from .models import (
-    CommandResponse,
     Device,
     FeatureControl,
     GatewayDeviceRefreshResult,
@@ -74,6 +74,21 @@ class _FixtureDiscoveryAdapter:
         return self._feature_data
 
 
+class _FixtureCommandAdapter:
+    """Return deterministic command responses without modifying fixtures."""
+
+    async def execute_command(
+        self, control: FeatureControl, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return a successful fixture command response."""
+        print(
+            f"[MOCK] Executing command '{control.command_name}' for feature "
+            f"'{control.parent_feature_name}' (param: {control.param_name}) "
+            f"with params: {parameters}"
+        )
+        return {"data": {"success": True, "reason": "Mock Execution Success"}}
+
+
 # Mapping of fixture names to device types
 # This provides consistent device_type values for mock devices
 DEVICE_TYPE_MAP: dict[str, str] = {
@@ -108,6 +123,7 @@ class MockViClient(ViClient):
         self._discovery_adapter: _DiscoveryAdapter = _FixtureDiscoveryAdapter(
             device_name
         )
+        self._command_adapter: _CommandAdapter = _FixtureCommandAdapter()
 
     @staticmethod
     def get_available_mock_devices() -> list[str]:
@@ -148,24 +164,3 @@ class MockViClient(ViClient):
             ]
             updated_devices.append(replace(device, features=enabled_and_ready_features))
         return GatewayDeviceRefreshResult(updated_devices, {})
-
-    async def _execute_command(
-        self,
-        control: FeatureControl,
-        payload: dict[str, Any],
-    ) -> CommandResponse:
-        """Mock execution of a command (Success).
-
-        Args:
-            control: The feature control block being executed.
-            payload: Validated parameters for the command.
-
-        Returns:
-            A CommandResponse indicating success.
-        """
-        print(
-            f"[MOCK] Executing command '{control.command_name}' for feature "
-            f"'{control.parent_feature_name}' (param: {control.param_name}) "
-            f"with params: {payload}"
-        )
-        return CommandResponse(success=True, reason="Mock Execution Success")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1027,6 +1027,92 @@ async def test_set_feature_returns_updated_device(load_fixture_json):
 
 
 @pytest.mark.asyncio
+async def test_execute_command_preserves_explicit_parameters(load_fixture_json):
+    """Execute an explicit command without enriching its parameter payload."""
+    # Arrange: Load a writable feature and configure its command endpoint.
+    fixtures_data = load_fixture_json("feature_heating_curve.json")
+    install_id = "123"
+    gw_serial = "GW123"
+    device_id = "0"
+    features_url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/{install_id}/gateways/{gw_serial}/devices/{device_id}/features/filter"
+    command_url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/{install_id}/gateways/{gw_serial}/devices/{device_id}/"
+        "features/heating.circuits.0.heating.curve/commands/setCurve"
+    )
+    parameters = {"slope": 0.7, "shift": 7.0}
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(features_url, payload={"data": fixtures_data})
+        mock_responses.post(command_url, payload={"data": {"success": True}})
+
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+            device = Device(
+                id=device_id,
+                gateway_serial=gw_serial,
+                installation_id=install_id,
+                model_id="Vitocal250A",
+                device_type="heatpump",
+                status="Online",
+            )
+            device = replace(device, features=await client.get_features(device))
+            slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
+
+            # Act: Submit the caller's complete parameter set.
+            response = await client.execute_command(slope_feature, parameters)
+
+            # Assert: The adapter sends the supplied parameters unchanged.
+            assert response.success
+            found_call = next(
+                call
+                for (method, url), calls in mock_responses.requests.items()
+                if method == "POST" and str(url) == command_url
+                for call in calls
+            )
+            assert found_call.kwargs["json"] == parameters
+
+
+@pytest.mark.asyncio
+async def test_execute_command_rejects_malformed_success_response(load_fixture_json):
+    """Translate malformed successful command responses into library errors."""
+    # Arrange: Return a valid JSON value that violates the command response contract.
+    fixtures_data = load_fixture_json("feature_heating_curve.json")
+    install_id = "123"
+    gw_serial = "GW123"
+    device_id = "0"
+    features_url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/{install_id}/gateways/{gw_serial}/devices/{device_id}/features/filter"
+    command_url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/{install_id}/gateways/{gw_serial}/devices/{device_id}/"
+        "features/heating.circuits.0.heating.curve/commands/setCurve"
+    )
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(features_url, payload={"data": fixtures_data})
+        mock_responses.post(command_url, payload=["unexpected"])
+
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+            device = Device(
+                id=device_id,
+                gateway_serial=gw_serial,
+                installation_id=install_id,
+                model_id="Vitocal250A",
+                device_type="heatpump",
+                status="Online",
+            )
+            device = replace(device, features=await client.get_features(device))
+            slope_feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+            assert slope_feature is not None
+
+            # Act and assert: The public client exposes a library exception.
+            with pytest.raises(
+                ViResponseError, match="Command response must be an object"
+            ):
+                await client.execute_command(slope_feature, {"slope": 0.7})
+
+
+@pytest.mark.asyncio
 async def test_set_feature_returns_unchanged_device_on_failure(load_fixture_json):
     """Verify device unchanged on command failure."""
     # Arrange: Load fixture and mock API failure.

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -360,13 +360,13 @@ async def test_async_main_rejects_malformed_credential_document(monkeypatch, tmp
 
 
 @pytest.mark.asyncio
-async def test_cmd_exec_success(mock_cli_context, capsys):
-    """Test successful command execution via CLI (Legacy/Advanced)."""
+async def test_cmd_exec_preserves_explicit_parameters(mock_cli_context, capsys):
+    """CLI executes every explicitly supplied advanced command parameter."""
     # Arrange: Create mock client, device, and fixture data for test.
     args = Namespace(
         feature_name="heating.curve.slope",
         command_name="setCurve",
-        params=["slope=1.4"],
+        params=["slope=1.4", "shift=0"],
         token_file="tokens.json",
         client_id=None,
         redirect_uri=None,
@@ -401,16 +401,7 @@ async def test_cmd_exec_success(mock_cli_context, capsys):
     mock_response.success = True
     mock_response.message = "OK"
     mock_response.reason = None
-    # Return tuple (response, device)
-    mock_device = Device(
-        id="DEV1",
-        gateway_serial="GW1",
-        installation_id="99",
-        model_id="Test",
-        device_type="heating",
-        status="ok",
-    )
-    mock_cli_context.client.set_feature.return_value = (mock_response, mock_device)
+    mock_cli_context.client.execute_command.return_value = mock_response
 
     with patch("vi_api_client.cli.setup_client_context") as mock_setup:
         mock_setup.return_value.__aenter__.return_value = mock_cli_context
@@ -427,12 +418,10 @@ async def test_cmd_exec_success(mock_cli_context, capsys):
         assert args_list[0].id == "DEV1"
         assert mock_cli_context.client.get_features.call_args[1] == {}
 
-        # Should call set_feature
-        mock_cli_context.client.set_feature.assert_called()
-        # Verify call args for set_feature: (device, feature, value)
-        call_args_set = mock_cli_context.client.set_feature.call_args[0]
-        assert call_args_set[0].get_feature("heating.curve.slope") is mock_feature
-        assert call_args_set[2] == 1.4  # Value parsed from float
+        mock_cli_context.client.execute_command.assert_awaited_once_with(
+            mock_feature, {"slope": 1.4, "shift": 0}
+        )
+        mock_cli_context.client.set_feature.assert_not_called()
 
         # Verify output
         captured = capsys.readouterr()
@@ -537,7 +526,7 @@ async def test_cmd_exec_validation_error(mock_cli_context, capsys):
     # If parsing fails to produce float, it might pass string to set_feature if logic allows,
     # OR if parse_cli_params works (it does strings).
     # "slope=invalid" -> params_dict={"slope": "invalid"} -> target_val="invalid"
-    mock_cli_context.client.set_feature.side_effect = error
+    mock_cli_context.client.execute_command.side_effect = error
 
     with patch("vi_api_client.cli.setup_client_context") as mock_setup:
         mock_setup.return_value.__aenter__.return_value = mock_cli_context

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -58,3 +58,22 @@ async def test_mock_feature_filters_apply_shared_enabled_and_name_semantics():
 
     # Assert: Shared filtering retains the requested enabled and ready feature only.
     assert [feature.name for feature in features] == ["device.serial"]
+
+
+@pytest.mark.asyncio
+async def test_mock_execute_command_is_offline_and_stateless():
+    """Mock command execution should not alter the loaded fixture features."""
+    # Arrange: Load a writable fixture feature through the public workflow.
+    client = MockViClient("Vitocal250A")
+    device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
+    device = await client.update_device(device)
+    feature = device.get_feature("heating.circuits.0.heating.curve.slope")
+    assert feature is not None
+
+    # Act: Execute a command with an explicit payload.
+    response = await client.execute_command(feature, {"slope": 0.7, "shift": 7.0})
+
+    # Assert: The response is deterministic and the fixture-derived value is unchanged.
+    assert response.success
+    assert response.reason == "Mock Execution Success"
+    assert feature.value == 0.6


### PR DESCRIPTION
## Summary
- add explicit client command execution through live and fixture adapters
- route CLI advanced command execution through the client API
- document and test the safe single-value and explicit command paths

Closes #54

## Validation
- .venv/bin/python -m ruff check .
- .venv/bin/python -m ruff format --check .
- .venv/bin/python -m pytest -q