### PR TITLE
feat: share gateway-scoped device refresh

### DIFF
--- a/src/vi_api_client/_discovery.py
+++ b/src/vi_api_client/_discovery.py
@@ -30,6 +30,12 @@ class _DiscoveryAdapter(Protocol):
         """Return the raw feature API envelope."""
         raise NotImplementedError
 
+    async def get_gateway_features(
+        self, devices: list[Device], payload: dict[str, bool]
+    ) -> dict[str, Any]:
+        """Return the raw gateway-scoped feature API envelope."""
+        raise NotImplementedError
+
 
 class _LiveDiscoveryAdapter:
     """Retrieve client envelopes through the authenticated HTTP connector."""
@@ -63,5 +69,16 @@ class _LiveDiscoveryAdapter:
         url = (
             f"{ENDPOINT_FEATURES}/{device.installation_id}/gateways/"
             f"{device.gateway_serial}/devices/{device.id}/features/filter"
+        )
+        return await self._connector.post(url, payload)
+
+    async def get_gateway_features(
+        self, devices: list[Device], payload: dict[str, bool]
+    ) -> dict[str, Any]:
+        """Return the raw gateway-scoped feature API envelope."""
+        first_device = devices[0]
+        url = (
+            f"{ENDPOINT_FEATURES}/{first_device.installation_id}/gateways/"
+            f"{first_device.gateway_serial}/features/filter"
         )
         return await self._connector.post(url, payload)

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -10,7 +10,6 @@ from ._commands import _CommandAdapter, _LiveCommandAdapter
 from ._discovery import _DiscoveryAdapter, _LiveDiscoveryAdapter
 from .auth import AbstractAuth
 from .connection import ViConnector
-from .const import ENDPOINT_FEATURES
 from .exceptions import ViError, ViResponseError, ViValidationError
 from .models import (
     CommandResponse,
@@ -231,18 +230,15 @@ class ViClient:
 
         self._validate_gateway_devices(devices)
 
-        first_device = devices[0]
-        url = (
-            f"{ENDPOINT_FEATURES}/{first_device.installation_id}/gateways/"
-            f"{first_device.gateway_serial}/features/filter"
-        )
         payload = {
             "includeDevicesFeatures": True,
             "skipDisabled": True,
             "skipNotReady": True,
         }
         try:
-            response = await self.connector.post(url, payload)
+            response = await self._discovery_adapter.get_gateway_features(
+                devices, payload
+            )
         except ViValidationError as error:
             if error.error_type == "DEVICE_COMMUNICATION_ERROR":
                 return await self._refresh_devices_individually(devices)

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -1,5 +1,4 @@
 import json
-from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -10,7 +9,6 @@ from .auth import AbstractAuth
 from .models import (
     Device,
     FeatureControl,
-    GatewayDeviceRefreshResult,
 )
 
 
@@ -61,6 +59,12 @@ class _FixtureDiscoveryAdapter:
         self, device: Device, payload: dict[str, bool | list[str]]
     ) -> dict[str, Any]:
         """Return the selected fixture's raw feature envelope."""
+        return self._load_feature_data()
+
+    async def get_gateway_features(
+        self, devices: list[Device], payload: dict[str, bool]
+    ) -> dict[str, Any]:
+        """Return the selected fixture's raw gateway-scoped feature envelope."""
         return self._load_feature_data()
 
     def _load_feature_data(self) -> dict[str, Any]:
@@ -137,30 +141,3 @@ class MockViClient(ViClient):
             for file in fixtures_dir.glob("*.json")
             if file.stem != "discovery"
         )
-
-    async def update_gateway_devices(
-        self, devices: list[Device]
-    ) -> GatewayDeviceRefreshResult:
-        """Refresh gateway devices from fixtures without network access.
-
-        Args:
-            devices: Existing devices belonging to one installation and gateway.
-
-        Returns:
-            Refreshed devices in input order with no device-specific errors.
-
-        Raises:
-            ValueError: If devices span multiple scopes or contain duplicate IDs.
-        """
-        if not devices:
-            return GatewayDeviceRefreshResult([], {})
-
-        self._validate_gateway_devices(devices)
-        updated_devices = []
-        for device in devices:
-            features = await self.get_features(device, only_enabled=True)
-            enabled_and_ready_features = [
-                feature for feature in features if feature.is_ready
-            ]
-            updated_devices.append(replace(device, features=enabled_and_ready_features))
-        return GatewayDeviceRefreshResult(updated_devices, {})

--- a/tests/test_gateway_device_refresh_contract.py
+++ b/tests/test_gateway_device_refresh_contract.py
@@ -1,0 +1,287 @@
+"""Shared gateway-scoped device refresh contract tests."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from vi_api_client.api import ViClient
+from vi_api_client.exceptions import ViResponseError, ViValidationError
+from vi_api_client.mock_client import MockViClient
+from vi_api_client.models import Device
+
+
+class _ScriptedGatewayDiscoveryAdapter:
+    """Provide scripted raw responses while recording gateway refresh calls."""
+
+    def __init__(
+        self,
+        gateway_response: dict[str, Any],
+        device_responses: dict[str, dict[str, Any]],
+    ) -> None:
+        self.gateway_response = gateway_response
+        self.device_responses = device_responses
+        self.calls: list[str] = []
+        self.gateway_error: ViValidationError | None = None
+        self.device_errors: dict[str, ViValidationError] = {}
+
+    async def get_installations(self) -> dict[str, Any]:
+        """Return an unused empty installation envelope."""
+        return {"data": []}
+
+    async def get_gateways(self) -> dict[str, Any]:
+        """Return an unused empty gateway envelope."""
+        return {"data": []}
+
+    async def get_devices(
+        self, installation_id: str, gateway_serial: str
+    ) -> dict[str, Any]:
+        """Return an unused empty device envelope."""
+        return {"data": []}
+
+    async def get_gateway_features(
+        self, devices: list[Device], payload: dict[str, bool]
+    ) -> dict[str, Any]:
+        """Return the scripted gateway-scoped response."""
+        self.calls.append("gateway")
+        if self.gateway_error is not None:
+            raise self.gateway_error
+        return self.gateway_response
+
+    async def get_features(
+        self, device: Device, payload: dict[str, bool | list[str]]
+    ) -> dict[str, Any]:
+        """Return the scripted individual device response."""
+        self.calls.append(f"device:{device.id}")
+        if device.id in self.device_errors:
+            raise self.device_errors[device.id]
+        return self.device_responses[device.id]
+
+
+def _build_gateway_device(device_id: str) -> Device:
+    """Build a device for gateway-scoped refresh contract tests."""
+    return Device(
+        id=device_id,
+        gateway_serial="gateway-1",
+        installation_id="installation-1",
+        model_id=f"model-{device_id}",
+        device_type="heating",
+        status="connected",
+    )
+
+
+def _create_live_client(adapter: _ScriptedGatewayDiscoveryAdapter) -> ViClient:
+    """Create a live client whose raw discovery boundary is scripted."""
+    client = ViClient.__new__(ViClient)
+    client._discovery_adapter = adapter
+    return client
+
+
+def _create_fixture_client(adapter: _ScriptedGatewayDiscoveryAdapter) -> MockViClient:
+    """Create a fixture client whose raw discovery boundary is scripted."""
+    client = MockViClient.__new__(MockViClient)
+    client._discovery_adapter = adapter
+    return client
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_falls_back_for_omitted_devices_and_preserves_order(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+):
+    """Both clients should share omission fallback and input-order behavior."""
+    # Arrange: The bulk response supplies only device 10; device 0 needs fallback.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={
+            "data": [
+                {
+                    "feature": "heating.status",
+                    "properties": {"value": "ready"},
+                    "uri": (
+                        "/iot/v2/features/installations/installation-1/gateways/"
+                        "gateway-1/devices/10/features/heating.status"
+                    ),
+                }
+            ]
+        },
+        device_responses={"0": {"data": []}},
+    )
+    client = create_client(adapter)
+    devices = [_build_gateway_device("10"), _build_gateway_device("0")]
+
+    # Act: Refresh from either raw-response adapter.
+    result = await client.update_gateway_devices(devices)
+
+    # Assert: Both use one bulk call, fall back only for the omission, and retain order.
+    assert adapter.calls == ["gateway", "device:0"]
+    assert [device.id for device in result.updated_devices] == ["10", "0"]
+    assert result.updated_devices[0].model_id == "model-10"
+    assert result.updated_devices[1].features == []
+    assert result.is_complete
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_groups_only_requested_device_features(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+):
+    """Both clients should ignore gateway-owned and unrelated device features."""
+    # Arrange: A complete bulk response includes requested, gateway, and unrelated data.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={
+            "data": [
+                {
+                    "feature": "heating.status",
+                    "properties": {"value": "ready"},
+                    "uri": "/devices/0/features/heating.status",
+                },
+                {
+                    "feature": "gateway.status",
+                    "properties": {"value": "online"},
+                    "uri": "/gateways/gateway-1/features/gateway.status",
+                },
+                {
+                    "feature": "device.serial",
+                    "properties": {"value": "other-device"},
+                    "uri": "/devices/99/features/device.serial",
+                },
+            ]
+        },
+        device_responses={},
+    )
+    client = create_client(adapter)
+
+    # Act: Refresh the only requested device from either raw-response adapter.
+    result = await client.update_gateway_devices([_build_gateway_device("0")])
+
+    # Assert: Only the requested device's feature is exposed and no fallback occurs.
+    assert adapter.calls == ["gateway"]
+    assert [feature.name for feature in result.updated_devices[0].features] == [
+        "heating.status"
+    ]
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_returns_device_specific_fallback_errors(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+):
+    """Both clients should retain successful devices beside fallback failures."""
+    # Arrange: Gateway failure triggers individual refresh; device 0 has a known error.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={"data": []},
+        device_responses={
+            "10": {
+                "data": [
+                    {
+                        "feature": "heating.status",
+                        "properties": {"value": "ready"},
+                        "uri": "/devices/10/features/heating.status",
+                    }
+                ]
+            }
+        },
+    )
+    adapter.gateway_error = ViValidationError(
+        "Gateway unavailable", error_type="DEVICE_COMMUNICATION_ERROR"
+    )
+    adapter.device_errors["0"] = ViValidationError(
+        "Device unavailable", error_type="DEVICE_NOT_FOUND"
+    )
+    client = create_client(adapter)
+
+    # Act: Refresh through the public gateway operation.
+    result = await client.update_gateway_devices(
+        [_build_gateway_device("10"), _build_gateway_device("0")]
+    )
+
+    # Assert: The successful device remains available with the known error isolated.
+    assert adapter.calls == ["gateway", "device:10", "device:0"]
+    assert [device.id for device in result.updated_devices] == ["10"]
+    assert result.errors_by_device_id["0"].error_type == "DEVICE_NOT_FOUND"
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_rejects_invalid_bulk_responses(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+):
+    """Both clients should expose malformed shared responses as public errors."""
+    # Arrange: Return a malformed successful gateway response.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={"data": [{"uri": "/devices/0/features/heating"}]},
+        device_responses={},
+    )
+    client = create_client(adapter)
+
+    # Act and assert: Invalid raw data aborts the shared refresh consistently.
+    with pytest.raises(ViResponseError, match="valid feature name"):
+        await client.update_gateway_devices([_build_gateway_device("0")])
+    assert adapter.calls == ["gateway"]
+
+
+@pytest.mark.parametrize(
+    ("devices", "error_message"),
+    [
+        ([_build_gateway_device("0"), _build_gateway_device("0")], "unique IDs"),
+        (
+            [
+                _build_gateway_device("0"),
+                Device(
+                    id="1",
+                    gateway_serial="gateway-2",
+                    installation_id="installation-1",
+                    model_id="model-1",
+                    device_type="heating",
+                    status="connected",
+                ),
+            ],
+            "same installation and gateway",
+        ),
+    ],
+)
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_rejects_ambiguous_device_sets_before_adapter_calls(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+    devices: list[Device],
+    error_message: str,
+):
+    """Both clients should reject ambiguous device sets before fetching features."""
+    # Arrange: Give both clients a scripted adapter that must not receive a request.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={"data": []}, device_responses={}
+    )
+    client = create_client(adapter)
+
+    # Act and assert: Conflicting scope or duplicate IDs are rejected before I/O.
+    with pytest.raises(ValueError, match=error_message):
+        await client.update_gateway_devices(devices)
+    assert adapter.calls == []
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_gateway_refresh_rejects_ambiguous_feature_ownership(
+    create_client: Callable[[_ScriptedGatewayDiscoveryAdapter], ViClient],
+):
+    """Both clients should reject feature URIs with multiple device owners."""
+    # Arrange: Return a feature URI that names two device path segments.
+    adapter = _ScriptedGatewayDiscoveryAdapter(
+        gateway_response={
+            "data": [
+                {
+                    "feature": "heating.status",
+                    "properties": {"value": "ready"},
+                    "uri": "/devices/0/features/devices/1/heating.status",
+                }
+            ]
+        },
+        device_responses={},
+    )
+    client = create_client(adapter)
+
+    # Act and assert: Ambiguous ownership is a shared response-contract failure.
+    with pytest.raises(ViResponseError, match="ambiguous device ownership"):
+        await client.update_gateway_devices([_build_gateway_device("0")])
+    assert adapter.calls == ["gateway"]

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -40,6 +40,23 @@ async def test_mock_update_device_returns_hydrated_copy_without_mutating_input()
 
 
 @pytest.mark.asyncio
+async def test_mock_gateway_refresh_uses_the_fixture_adapter_without_authentication():
+    """Mock gateway refresh should reuse the client workflow without credentials."""
+    # Arrange: Discover the deterministic fixture device through an offline client.
+    client = MockViClient("Vitodens200W")
+    device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
+
+    # Act: Refresh the discovered device through the inherited gateway operation.
+    result = await client.update_gateway_devices([device])
+
+    # Assert: The fixture refresh is complete and preserves the source device metadata.
+    assert result.is_complete
+    assert result.updated_devices[0].id == device.id
+    assert result.updated_devices[0].model_id == device.model_id
+    assert result.updated_devices[0].features
+
+
+@pytest.mark.asyncio
 async def test_mock_feature_filters_apply_shared_enabled_and_name_semantics():
     """Mock filtering should retain only requested enabled and ready features."""
     # Arrange: Select a fixture that includes disabled features.


### PR DESCRIPTION
Closes #55

## Summary

Moves gateway-scoped device refresh orchestration into the shared `ViClient` core, so live and fixture clients now differ only at the raw-response adapter boundary.

## Changes

- Added gateway-scoped feature retrieval to the private discovery-adapter interface.
- Routed both live HTTP and fixture data through the same refresh algorithm.
- Removed the mock-specific `update_gateway_devices` implementation.
- Added shared contract tests for bulk success, omissions and fallback, partial per-device failures, ordering and metadata, feature isolation, malformed responses, ambiguous ownership, duplicate IDs, and mixed scopes.
- Verified the fixture client remains offline and authentication-free.

## Validation

- `ruff check .`
- `ruff format --check .`
- `pytest -q` — 164 passed

## Review

- Standards review: no findings.
- Specification review: no findings.