### PR TITLE
docs: describe current client API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,10 @@ Designed for integration with Home Assistant and other async Python applications
 - **Auto-Discovery**: Automatically finds installations, gateways, and devices.
 - **Recursive Feature Flattening**: Converts complex nested API responses into a simple, flat list of features (e.g., `heating.circuits.0.heating.curve.shift`).
 - **Gateway-Scoped Refresh**: Refreshes multiple known devices with one normal-case request while preserving partial successes.
-- **Command Execution**: Supports writing values with automatic parameter resolution (e.g. `setCurve`).
-- **Mock Client**: Includes a robust `MockViClient` for offline development and testing.
-
-## Next Major Release
-
-The next major release will remove the deprecated Analytics API:
-`ViClient.get_consumption`, `MockViClient.get_consumption`, and the
-`vi-client get-consumption` command. Read consumption through Devices API features such as
-`heating.power.consumption.total` and their existing flattened aliases instead.
-
-It also removes raw transport access: `ViClient.connector`, `ViConnector`, and
-the `vi_api_client.connection` module are no longer supported. Use the typed
-discovery, refresh, and write methods on `ViClient` instead. For multi-parameter
-writes, use `execute_command(feature, parameters)`; use `set_feature` for a
-single writable feature and automatic dependency resolution.
-
-`MockViClient` now takes only a fixture device name. Remove any redundant mock
-authentication argument. It remains a `ViClient` subtype and all high-level
-methods continue to work unchanged. Fixture clients never create a session or
-make network requests.
-
-Consumers such as `vi_climate_devices` must update their dependency to this
-major release, remove mock authentication arguments, and import public models
-from the package root (for example, `from vi_api_client import Device, Feature`)
-rather than private transport modules.
+- **Command Execution**: Supports safe single-feature writes with automatic
+  parameter resolution and explicit multi-parameter commands.
+- **Mock Client**: Runs the same client workflows against bundled real-device
+  responses without authentication, sessions, or network requests.
 
 ## Installation
 
@@ -111,10 +90,24 @@ async def main():
 
         # 1. Get Installations & Gateways
         installations = await client.get_installations()
+        if not installations:
+            return
+        installation = installations[0]
+
         gateways = await client.get_gateways()
+        gateway = next(
+            (
+                gateway
+                for gateway in gateways
+                if gateway.installation_id == installation.id
+            ),
+            None,
+        )
+        if gateway is None:
+            return
 
         # 2. Discover and refresh devices behind one gateway
-        devices = await client.get_devices(installations[0].id, gateways[0].serial)
+        devices = await client.get_devices(installation.id, gateway.serial)
         refresh = await client.update_gateway_devices(devices)
         for device_id, error in refresh.errors_by_device_id.items():
             print(f"Device {device_id} could not be refreshed: {error}")
@@ -127,7 +120,7 @@ async def main():
         for feature in device.features:
             print(f"{feature.name}: {feature.value}")
 
-        # 4. Write a Feature
+        # 4. Write one Feature with automatic dependency resolution
         # Find a writable feature (e.g. heating curve slope)
         slope = next(
             (f for f in device.features if "curve.slope" in f.name and f.is_writable),

--- a/demo_live.py
+++ b/demo_live.py
@@ -15,7 +15,7 @@ import aiohttp
 sys.path.insert(0, str(Path("src").resolve()))
 
 
-from vi_api_client import OAuth, ViClient
+from vi_api_client import OAuth, ViAuthError, ViClient
 from vi_api_client.utils import format_feature
 
 CLIENT_ID = os.getenv("VIESSMANN_CLIENT_ID", "YOUR_CLIENT_ID")
@@ -99,15 +99,13 @@ async def main():
     print("🚀 Viessmann Library Demo (IoT API)")
     print("=" * 40 + "\n")
 
-    connector = aiohttp.TCPConnector(ssl=False)
-
-    async with aiohttp.ClientSession(connector=connector) as session:
+    async with aiohttp.ClientSession() as session:
         auth = OAuth(CLIENT_ID, REDIRECT_URI, TOKEN_FILE, websession=session)
 
         try:
             await auth.async_get_access_token()
             print("✅ Authentication successful.\n")
-        except Exception:
+        except ViAuthError:
             print("⚠️  No valid tokens found.")
             print(f"Run: 'vi-client login --client-id {CLIENT_ID}'")
             return

--- a/demo_simple.py
+++ b/demo_simple.py
@@ -15,8 +15,7 @@ import aiohttp
 # Ensure we can import the local package
 sys.path.insert(0, str(Path("src").resolve()))
 
-from vi_api_client import ViClient
-from vi_api_client.auth import OAuth
+from vi_api_client import OAuth, ViAuthError, ViClient
 from vi_api_client.utils import format_feature
 
 # Configuration
@@ -28,9 +27,7 @@ TOKEN_FILE = os.getenv("VIESSMANN_TOKEN_FILE", "tokens.json")
 
 async def main():
     """Run the simple demo."""
-    connector = aiohttp.TCPConnector(ssl=False)  # Use insecure for demo
-
-    async with aiohttp.ClientSession(connector=connector) as session:
+    async with aiohttp.ClientSession() as session:
         # 1. Setup Authentication
         auth = OAuth(
             client_id=CLIENT_ID,
@@ -41,7 +38,7 @@ async def main():
 
         try:
             await auth.async_get_access_token()
-        except Exception:
+        except ViAuthError:
             print("Please login first using: vi-client login")
             return
 
@@ -58,6 +55,9 @@ async def main():
         devices = await client.get_devices(
             gateway.installation_id, gateway.serial, include_features=True
         )
+        if not devices:
+            print("No devices found.")
+            return
 
         # Prefer "0" (Heating System) over Gateway
         device = next((device for device in devices if device.id == "0"), devices[0])

--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -31,11 +31,10 @@ import os
 
 import aiohttp
 
-from vi_api_client import ViClient
-from vi_api_client.auth import OAuth
+from vi_api_client import OAuth, ViClient
 
 # Configuration
-CLIENT_ID = os.getenv("VIESSMANN_CLIENT_ID")
+CLIENT_ID = os.environ["VIESSMANN_CLIENT_ID"]
 REDIRECT_URI = "http://localhost:4200/"
 TOKEN_FILE = "tokens.json"
 
@@ -59,20 +58,31 @@ async def main():
             print("No installations found.")
             return
 
-        inst_id = installations[0].id
-        print(f"Using Installation: {inst_id}")
+        installation = installations[0]
+        print(f"Using Installation: {installation.id}")
 
         gateways = await client.get_gateways()
-        if not gateways:
-            print("No gateways found.")
+        gateway = next(
+            (
+                gateway
+                for gateway in gateways
+                if gateway.installation_id == installation.id
+            ),
+            None,
+        )
+        if gateway is None:
+            print("No gateway found for the selected installation.")
             return
 
-        gw_serial = gateways[0].serial
-        print(f"Using Gateway: {gw_serial}")
+        print(f"Using Gateway: {gateway.serial}")
 
         # Pick the heating device (usually id="0")
         # include_features=True ensures we get the full data immediately
-        devices = await client.get_devices(inst_id, gw_serial, include_features=True)
+        devices = await client.get_devices(
+            installation.id,
+            gateway.serial,
+            include_features=True,
+        )
 
         if not devices:
             print("No devices found.")
@@ -95,9 +105,6 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
-
-
-
 ### 2. Executing Commands
 
 To change settings (e.g., set heating mode), you use the high-level `set_feature` method.
@@ -137,7 +144,7 @@ async def set_heating_mode(client, device):
 
 - **[API Concepts](02_api_structure.md)**: understand the data-driven design.
 - **[Authentication](03_auth_reference.md)**: setup tokens and sessions.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[Client Reference](05_client_reference.md)**: methods on `ViClient`.
 - **[CLI Reference](06_cli_reference.md)**: terminal usage.
 - **[Exceptions Reference](07_exceptions_reference.md)**: error handling.

--- a/docs/02_api_structure.md
+++ b/docs/02_api_structure.md
@@ -78,7 +78,7 @@ If a feature is writable, it has a `.control` attribute with metadata:
 
 *   `command_name`: The internal command to send (e.g., `setCurve`)
 *   `param_name`: The parameter this feature maps to (e.g., `slope`)
-*   `required_params`: List of **all** parameters required by this command, including `param_name` (e.g., `['slope', 'shift']`)
+*   `required_params`: Parameter names used to assemble the command payload, including `param_name` (e.g., `['slope', 'shift']`)
 *   `parent_feature_name`: Name of the parent feature, used to resolve sibling dependencies (e.g., `heating.circuits.0.heating.curve`)
 *   `uri`: The API URI endpoint for executing the command
 *   `min` / `max` / `step`: Numerical constraints
@@ -93,7 +93,10 @@ Because of this flat design, usage is consistent:
 **1. Reading (Get Features)**
 ```python
 # Get a specific feature by name (e.g. heating curve slope)
-features = await client.get_features(device, ["heating.circuits.0.heating.curve.slope"])
+features = await client.get_features(
+    device,
+    feature_names=["heating.circuits.0.heating.curve.slope"],
+)
 print(features[0].value)
 # Output: 1.4
 ```
@@ -127,7 +130,7 @@ consumer owns polling cadence and stale-state policy.
 
 ## Summary
 
-*   **Everything is a Feature**: No more "Properties" vs "Features".
+*   **Everything is a Feature**: Scalar properties are exposed as addressable `Feature` objects.
 *   **Flat Names**: Use full names like `heating.circuits.0.heating.curve.slope`.
 *   **Simple Set**: Use `set_feature(device, feature, value)`.
 *   **Explicit Multi-Device Refresh**: Use `update_gateway_devices` for known devices behind one gateway.
@@ -136,7 +139,7 @@ consumer owns polling cadence and stale-state policy.
 
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.
 - **[Authentication](03_auth_reference.md)**: setup tokens and sessions.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[Client Reference](05_client_reference.md)**: methods on `ViClient`.
 - **[CLI Reference](06_cli_reference.md)**: terminal usage.
 - **[Exceptions Reference](07_exceptions_reference.md)**: error handling.

--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -69,11 +69,11 @@ from vi_api_client import OAuth
 | :--- | :--- | :--- | :--- |
 | `client_id` | `str` | Yes | Your Client ID from the [Viessmann Developer Portal](https://developer.viessmann.com/). |
 | `redirect_uri` | `str` | Yes | Must match your registered Redirect URI (e.g. `http://localhost:4200/`). |
-| `token_file` | `str` | No | Path to store/load tokens (JSON). Defaults to None (memory only). |
+| `token_file` | `Path \| str` | Yes | Path to the JSON credential document used to store and load tokens. |
 | `websession` | `ClientSession` | No | `aiohttp` session to share connections. |
 
 ### Automatic Token Refresh
-If `token_file` is provided, the class automatically:
+The class automatically:
 1.  **Loads** tokens from disk on startup.
 2.  **Saves** new tokens to disk whenever they are refreshed.
 
@@ -105,7 +105,7 @@ Tokens are stored in `token_file` as:
 
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.
 - **[API Concepts](02_api_structure.md)**: understand the data-driven design.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[Client Reference](05_client_reference.md)**: methods on `ViClient`.
 - **[CLI Reference](06_cli_reference.md)**: terminal usage.
 - **[Exceptions Reference](07_exceptions_reference.md)**: error handling.

--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -11,7 +11,7 @@ Represents an installation site (House).
 | `id` | `str` | Unique installation ID. | `'123456789'` |
 | `description` | `str` | Description of the installation. | `'Home'` |
 | `alias` | `str` | Alias name. | `'My House'` |
-| `address` | `Dict` | Address information. | `{'city': 'Berlin', ...}` |
+| `address` | `dict[str, Any]` | Address information. | `{'city': 'Berlin', ...}` |
 
 ## Gateway
 
@@ -36,7 +36,7 @@ Represents a physical device attached to a gateway (e.g. Heating System).
 | `model_id` | `str` | Model name (e.g., "E3_Vitocal_16"). | `'E3_Vitocal_250A'` |
 | `device_type` | `str` | Device type (e.g., "heating", "tcu"). | `'heating'` |
 | `status` | `str` | Connection status (e.g., "Online"). | `'Online'` |
-| `features` | `List[Feature]` | List of features supported by this device. | `[Feature(...)]` |
+| `features` | `list[Feature]` | Features supported by this device. | `[Feature(...)]` |
 
 
 
@@ -48,11 +48,11 @@ The core unit of information. A feature represents a single property (Sensor) or
 | :--- | :--- | :--- | :--- |
 | `name` | `str` | Unique flat feature name. | `'heating.circuits.0.heating.curve.slope'` |
 | `value` | `Any` | Primary value of the feature (scalar). | `1.4` |
-| `unit` | `str` | Unit of measurement. | `None` |
+| `unit` | `str \| None` | Unit of measurement, when supplied. | `None` |
 | `is_ready` | `bool` | Whether the data point is currently valid. | `True` |
 | `is_enabled` | `bool` | Whether this feature is supported. | `True` |
 | `is_writable` | `bool` | `True` if this feature can be modified. | `True` |
-| `control` | `Optional[FeatureControl]` | Metadata for writing to this feature. | `FeatureControl(...)` |
+| `control` | `FeatureControl \| None` | Metadata for writing to this feature. | `FeatureControl(...)` |
 
 ### Formatting Values
 
@@ -74,27 +74,28 @@ This object abstracts away the complexity of Viessmann Commands. You rarely inte
 | :--- | :--- | :--- | :--- |
 | `command_name` | `str` | The internal command name. | `'setCurve'` |
 | `param_name` | `str` | The parameter name this feature maps to. | `'slope'` |
-| `required_params` | `List[str]` | List of all parameters required for this command. | `['slope', 'shift']` |
+| `required_params` | `list[str]` | Parameter names used to assemble the command payload. | `['slope', 'shift']` |
 | `parent_feature_name` | `str` | Name of the parent feature (used for sibling lookups). | `'heating.circuits.0.heating.curve'` |
 | `uri` | `str` | The API endpoint for this specific command. | `'.../features/heating.circuits.0...'` |
-| `min` | `float` | Minimum allowed value (numeric). | `0.2` |
-| `max` | `float` | Maximum allowed value (numeric). | `3.5` |
-| `step` | `float` | Step increment (numeric). | `0.1` |
-| `value_type` | `str` | API command value type, e.g. `number`, `boolean`, or `string`. | `'number'` |
-| `options` | `List[str]` | List of valid options (enum). | `['eco', 'comfort']` |
-| `pattern` | `str` | Regex pattern for validation (string). | `'^[a-z]+$'` |
-| `min_length` | `int` | Minimum string length. | `1` |
-| `max_length` | `int` | Maximum string length. | `20` |
+| `min` | `float \| None` | Minimum allowed value (numeric). | `0.2` |
+| `max` | `float \| None` | Maximum allowed value (numeric). | `3.5` |
+| `step` | `float \| None` | Step increment (numeric). | `0.1` |
+| `value_type` | `str \| None` | API command value type, e.g. `number`, `boolean`, or `string`. | `'number'` |
+| `options` | `list[Any] \| None` | Valid enum values. | `['eco', 'comfort']` |
+| `pattern` | `str \| None` | Regex pattern for validation (string). | `'^[a-z]+$'` |
+| `min_length` | `int \| None` | Minimum string length. | `1` |
+| `max_length` | `int \| None` | Maximum string length. | `20` |
 
 ## CommandResponse
 
-Result of a command execution (first element of tuple returned by `set_feature`).
+Result of a command execution. It is returned directly by `execute_command`
+and as the first element of the tuple returned by `set_feature`.
 
 | Property | Type | Description | Example |
 | :--- | :--- | :--- | :--- |
 | `success` | `bool` | `True` if the command succeeded. | `True` |
-| `message` | `str` | Optional message from the API. | `'Command accepted'` |
-| `reason` | `str` | Optional failure reason or details. | `'Feature not ready'` |
+| `message` | `str \| None` | Optional message from the API. | `'Command accepted'` |
+| `reason` | `str \| None` | Optional failure reason or details. | `'Feature not ready'` |
 
 **Usage**:
 ```python
@@ -112,8 +113,8 @@ as result values rather than mutate them.
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| `updated_devices` | `List[Device]` | New device instances that refreshed successfully, in their relative input order. |
-| `errors_by_device_id` | `Dict[str, ViError]` | Recognized device-specific failures keyed by device ID. Failed original devices are not included in `updated_devices`. |
+| `updated_devices` | `list[Device]` | New device instances that refreshed successfully, in their relative input order. |
+| `errors_by_device_id` | `dict[str, ViError]` | Recognized device-specific failures keyed by device ID. Failed original devices are not included in `updated_devices`. |
 | `is_complete` | `bool` | `True` when no device-specific failures occurred. |
 
 ## Next Steps

--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -14,59 +14,49 @@ from vi_api_client import ViClient
 | :--- | :--- | :--- |
 | `auth` | `AbstractAuth` | An authenticated `Auth` instance (e.g., `OAuth`). |
 
-## v2 Migration
+## Client contract
 
-`ViClient` no longer exposes `connector`, and `ViConnector` plus the
-`vi_api_client.connection` module have been removed. Use the typed methods on
-this page instead; there is no generic raw HTTP replacement. Use
-`execute_command(feature, parameters)` for a complete explicit command payload,
-or `set_feature(device, feature, value)` for a safe single-feature write with
-dependency resolution.
+`ViClient` exposes typed discovery, refresh, and write operations rather than a
+generic HTTP interface. Use `set_feature(device, feature, value)` for a safe
+single-feature write with dependency resolution, or
+`execute_command(feature, parameters)` when the complete command payload is
+already known.
 
-`MockViClient` remains a `ViClient` subtype, but its constructor is now
-`MockViClient(device_name)` only. Remove any unused mock authentication argument.
-Fixture-backed clients load local data only and never construct authentication,
-sessions, or transports.
+An application that supplies `OAuth(websession=session)` owns and closes that
+session. An `AbstractAuth` provider closes only a session it created itself.
 
-The high-level discovery, hydration, filtering, immutable `update_device`,
-gateway refresh, `set_feature`, and `execute_command` methods are unchanged.
-An application that supplies `OAuth(websession=session)` continues to own and
-close that session; an `AbstractAuth` provider still closes only a session it
-created itself.
-
-Downstream consumers, including `vi_climate_devices`, need a dependency update,
-removal of redundant mock authentication arguments, and package-root model
-imports such as `from vi_api_client import Device, Feature`. No changes to that
-separate repository are included here.
+`MockViClient(device_name)` is a `ViClient` subtype backed by bundled device
+responses. It supports the same high-level methods without constructing
+authentication, sessions, or network transports.
 
 ## Discovery Methods
 
 Methods to discover the structure of your heating system.
 
-### `get_installations() -> List[Installation]`
+### `get_installations() -> list[Installation]`
 Fetches all available installations.
 *   **Returns**: List of `Installation` objects.
 
-### `get_gateways() -> List[Gateway]`
+### `get_gateways() -> list[Gateway]`
 Fetches all gateways (automatically linked to installations).
 *   **Returns**: List of `Gateway` objects.
 
-### `get_devices(installation_id: str, gateway_serial: str, include_features: bool = False, only_active_features: bool = False) -> List[Device]`
+### `get_devices(installation_id: str, gateway_serial: str, include_features: bool = False, only_active_features: bool = False) -> list[Device]`
 Fetches devices attached to a specific gateway.
 
 *   **Parameters**:
     *   `installation_id`: Installation ID (string).
     *   `gateway_serial`: Gateway serial number.
     *   `include_features`: If `True`, automatically populates the `features` list (Default `False`).
-    *   `only_active_features`: If `include_features=True`, only fetches enabled features (Default `False`).
+    *   `only_active_features`: If `include_features=True`, only returns enabled and ready features (Default `False`).
 *   **Returns**: List of `Device` objects. If `include_features=True`, the `features` property will be populated.
 
-### `get_full_installation_status(installation_id: str, only_enabled: bool = True) -> List[Device]`
+### `get_full_installation_status(installation_id: str, only_enabled: bool = True) -> list[Device]`
 Fetches the complete status of an installation, including all devices and their features.
 
 *   **Parameters**:
     *   `installation_id`: The ID of the installation to scan.
-    *   `only_enabled`: if `True` (default), only fetches active features.
+    *   `only_enabled`: if `True` (default), only returns enabled and ready features.
 *   **Returns**: List of `Device` objects, where each device has its `features` attribute fully populated.
 *   **Use Case**: Initial startup (e.g., Home Assistant integration load) to populate the entire entity registry at once.
 
@@ -74,12 +64,12 @@ Fetches the complete status of an installation, including all devices and their 
 
 Methods to read data and control the device.
 
-### `get_features(device: Device, only_enabled: bool = False, feature_names: List[str] = None) -> List[Feature]`
+### `get_features(device: Device, only_enabled: bool = False, feature_names: list[str] | None = None) -> list[Feature]`
 Fetches features for a specific device. This is the primary method to read data.
 
 *   **Parameters**:
     *   `device`: A `Device` object.
-    *   `only_enabled`: if `True`, only returns features that are enabled by the device configuration.
+    *   `only_enabled`: if `True`, only returns features that are enabled and ready.
     *   `feature_names`: Optional list of feature names to fetch (e.g. `["heating.sensors.temperature.outside"]`). If None, fetches all features.
 *   **Returns**: List of `Feature` objects.
 *   **Performance**: If `feature_names` is provided, the request is optimized to fetch only those specific features.
@@ -89,11 +79,11 @@ Refreshes a specific device by refetching all its features.
 
 *   **Parameters**:
     *   `device`: The `Device` object to update.
-    *   `only_enabled`: if `True`, only fetches active features (Performance optimization).
+    *   `only_enabled`: if `True`, only returns enabled and ready features (default `True`).
 *   **Returns**: A new `Device` instance with updated features.
 *   **Best for**: Efficient polling. Use this instead of re-discovering the entire installation hierarchy if you already have a `Device` object.
 
-### `update_gateway_devices(devices: List[Device]) -> GatewayDeviceRefreshResult`
+### `update_gateway_devices(devices: list[Device]) -> GatewayDeviceRefreshResult`
 
 Refreshes known devices belonging to one installation and gateway. The normal
 path uses one POST feature-filter request and retrieves enabled and ready
@@ -118,9 +108,9 @@ for device_id, error in result.errors_by_device_id.items():
     handle_unavailable_device(device_id, error.error_type)
 ```
 
-This method is explicit: `get_features`, `update_device`, `get_devices`, and
-`get_full_installation_status` continue to use their existing request and error
-semantics.
+`get_features`, `update_device`, `get_devices`, and
+`get_full_installation_status` use their single-device request and error
+semantics rather than this gateway-scoped partial-result contract.
 
 ### `set_feature(device: Device, feature: Feature, target_value: Any) -> tuple[CommandResponse, Device]`
 Sets a new value for a writable feature and returns an optimistically updated device.
@@ -133,7 +123,8 @@ Sets a new value for a writable feature and returns an optimistically updated de
     *   `CommandResponse`: Object with `success`, `message`, and `reason` fields.
     *   `Device`: Updated device with the feature value optimistically set (on success) or unchanged (on failure).
 *   **Raises**:
-    *   `ViValidationError` if the value violates constraints (min/max/options).
+    *   `ValueError` if the feature is read-only or the value violates client-side constraints.
+    *   `ViValidationError` if the API rejects the generated command payload.
     *   `ViConnectionError` if the API call fails.
 *   **Magic**: This method automatically resolves the correct command name and parameter name from the feature's definition.
 *   **Important**: Always use the returned `Device` for subsequent calls to ensure correct dependency resolution for interdependent features.
@@ -157,6 +148,9 @@ parameter is sent unchanged.
 Use it only when the caller already has the complete command payload, such as
 an advanced integration writing both heating-curve values at once.
 
+The method raises `ValueError` when the supplied feature is read-only. API and
+connection failures use the corresponding `ViError` subclasses.
+
 ```python
 response = await client.execute_command(slope_feature, {"slope": 0.7, "shift": 7.0})
 ```
@@ -166,6 +160,6 @@ response = await client.execute_command(slope_feature, {"slope": 0.7, "shift": 7
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.
 - **[API Concepts](02_api_structure.md)**: understand the data-driven design.
 - **[Authentication](03_auth_reference.md)**: setup tokens and sessions.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[CLI Reference](06_cli_reference.md)**: terminal usage.
 - **[Exceptions Reference](07_exceptions_reference.md)**: error handling.

--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -21,8 +21,9 @@ vi-client login --client-id <YOUR_CLIENT_ID> --redirect-uri <YOUR_REDIRECT_URI>
 ```
 Follow the URL, log in, and paste the code back into the terminal.
 The client ID and redirect URI used during login are saved with the tokens, so
-later commands can reuse them without repeating `--client-id`. Environment
-variables and explicit command-line arguments continue to take precedence.
+later commands can reuse them without repeating `--client-id`. Configuration
+precedence is command-line arguments, environment variables, the credential
+document, and finally the default redirect URI.
 If the credential document is malformed, the command exits unsuccessfully and
 leaves the file unchanged; repair or remove it before trying again.
 
@@ -40,17 +41,17 @@ Feature names vary by device model (e.g., heat pumps vs gas boilers). Use this t
 # List all features (names only)
 vi-client list-features
 
-# List only enabled features (names only)
+# List only enabled and ready features (names only)
 vi-client list-features --enabled
 
-# List enabled features WITH values - THIS IS THE MOST USEFUL COMMAND!
+# List enabled and ready features with values
 vi-client list-features --enabled --values
 
 # Output as JSON
 vi-client list-features --json
 ```
 *Note: This auto-detects the first device. You can specify `--gateway-serial` and `--device-id` if needed.*
-*Note: For `heating.power.consumption.{cooling,dhw,heating,total}`, the flattened feature list may include one synthetic alias feature per base feature: `...currentYear`. Additional synthetic `currentDay` and `currentMonth` aliases are no longer generated.*
+*Note: For `heating.power.consumption.{cooling,dhw,heating,total}`, the flattened feature list may include one synthetic `...currentYear` alias per base feature. `currentDay` and `currentMonth` aliases are not generated.*
 
 ## 4. Fetch Feature Details
 Get the current value of a specific feature.
@@ -84,7 +85,7 @@ The CLI converts values according to the feature's command type: numeric values
 become numbers, `true`/`false` become booleans, and text values such as `auto`
 or `01` remain strings. It then validates the value against the feature constraints.
 
-## 7. Advanced: Execute Raw Command
+## 7. Advanced: Execute an Explicit Command
 If you need to execute a command with multiple parameters at once (rare), you can use `exec`.
 
 ```bash
@@ -126,6 +127,6 @@ vi-client get-feature "heating.circuits.0" --insecure
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.
 - **[API Concepts](02_api_structure.md)**: understand the data-driven design.
 - **[Authentication](03_auth_reference.md)**: setup tokens and sessions.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[Client Reference](05_client_reference.md)**: methods on `ViClient`.
 - **[Exceptions Reference](07_exceptions_reference.md)**: error handling.

--- a/docs/07_exceptions_reference.md
+++ b/docs/07_exceptions_reference.md
@@ -51,7 +51,8 @@ When requesting a feature that isn't supported by a device, the API returns 404.
 try:
     # Trying to get a specific feature that might not exist
     features = await client.get_features(
-        device, ["heating.sensors.volumetricFlow.share"]
+        device,
+        feature_names=["heating.sensors.volumetricFlow.share"],
     )
     if not features:
         print("Feature not found (Filtered out or 404).")
@@ -77,6 +78,6 @@ except ViRateLimitError:
 - **[Getting Started](01_getting_started.md)**: installation and basic usage.
 - **[API Concepts](02_api_structure.md)**: understand the data-driven design.
 - **[Authentication](03_auth_reference.md)**: setup tokens and sessions.
-- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `Device`, and `Command`.
+- **[Models Reference](04_models_reference.md)**: detailed documentation of `Feature`, `FeatureControl`, `Device`, and command results.
 - **[Client Reference](05_client_reference.md)**: methods on `ViClient`.
 - **[CLI Reference](06_cli_reference.md)**: terminal usage.


### PR DESCRIPTION
## Summary

- replace release and migration comparisons with a direct description of the current client contract
- align authentication, filtering, command, model, and mock-client documentation with the implemented API
- correct feature-filter examples, installation-to-gateway selection, and the required credential-file argument
- update demo programs to use the public package exports and normal TLS verification

## Validation

- `ruff check .`
- `ruff format --check .`
- `pyright --pythonpath .venv/bin/python`
- `python -m pytest -q` (168 passed)
- `git diff --check`
- local Markdown link validation
