### PR TITLE
Make public models immutable snapshots

### DIFF
--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -11,7 +11,7 @@ Represents an installation site (House).
 | `id` | `str` | Unique installation ID. | `'123456789'` |
 | `description` | `str` | Description of the installation. | `'Home'` |
 | `alias` | `str` | Alias name. | `'My House'` |
-| `address` | `dict[str, Any]` | Address information. | `{'city': 'Berlin', ...}` |
+| `address` | `Mapping[str, Any]` | Read-only address information. | `{'city': 'Berlin', ...}` |
 
 ## Gateway
 
@@ -36,7 +36,7 @@ Represents a physical device attached to a gateway (e.g. Heating System).
 | `model_id` | `str` | Model name (e.g., "E3_Vitocal_16"). | `'E3_Vitocal_250A'` |
 | `device_type` | `str` | Device type (e.g., "heating", "tcu"). | `'heating'` |
 | `status` | `str` | Connection status (e.g., "Online"). | `'Online'` |
-| `features` | `list[Feature]` | Features supported by this device. | `[Feature(...)]` |
+| `features` | `Sequence[Feature]` | Read-only features supported by this device. | `(Feature(...),)` |
 
 
 
@@ -74,14 +74,14 @@ This object abstracts away the complexity of Viessmann Commands. You rarely inte
 | :--- | :--- | :--- | :--- |
 | `command_name` | `str` | The internal command name. | `'setCurve'` |
 | `param_name` | `str` | The parameter name this feature maps to. | `'slope'` |
-| `required_params` | `list[str]` | Parameter names used to assemble the command payload. | `['slope', 'shift']` |
+| `required_params` | `Sequence[str]` | Read-only parameter names used to assemble the command payload. | `('slope', 'shift')` |
 | `parent_feature_name` | `str` | Name of the parent feature (used for sibling lookups). | `'heating.circuits.0.heating.curve'` |
 | `uri` | `str` | The API endpoint for this specific command. | `'.../features/heating.circuits.0...'` |
 | `min` | `float \| None` | Minimum allowed value (numeric). | `0.2` |
 | `max` | `float \| None` | Maximum allowed value (numeric). | `3.5` |
 | `step` | `float \| None` | Step increment (numeric). | `0.1` |
 | `value_type` | `str \| None` | API command value type, e.g. `number`, `boolean`, or `string`. | `'number'` |
-| `options` | `list[Any] \| None` | Valid enum values. | `['eco', 'comfort']` |
+| `options` | `Sequence[Any] \| None` | Read-only valid enum values. | `('eco', 'comfort')` |
 | `pattern` | `str \| None` | Regex pattern for validation (string). | `'^[a-z]+$'` |
 | `min_length` | `int \| None` | Minimum string length. | `1` |
 | `max_length` | `int \| None` | Maximum string length. | `20` |
@@ -107,14 +107,13 @@ if response.success:
 
 ## GatewayDeviceRefreshResult
 
-Frozen result dataclass returned by `update_gateway_devices`. Its attributes
-cannot be reassigned; callers should also treat the contained list and mapping
-as result values rather than mutate them.
+Frozen result dataclass returned by `update_gateway_devices`. Its collection
+attributes are immutable snapshots.
 
 | Property | Type | Description |
 | :--- | :--- | :--- |
-| `updated_devices` | `list[Device]` | New device instances that refreshed successfully, in their relative input order. |
-| `errors_by_device_id` | `dict[str, ViError]` | Recognized device-specific failures keyed by device ID. Failed original devices are not included in `updated_devices`. |
+| `updated_devices` | `Sequence[Device]` | Read-only new device instances that refreshed successfully, in their relative input order. |
+| `errors_by_device_id` | `Mapping[str, ViError]` | Read-only recognized device-specific failures keyed by device ID. Failed original devices are not included in `updated_devices`. |
 | `is_complete` | `bool` | `True` when no device-specific failures occurred. |
 
 ## Next Steps

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -125,6 +125,9 @@ class ViClient:
 
         Returns:
             List of Feature objects (flattened).
+
+        Raises:
+            ViResponseError: If the API response contains duplicate feature names.
         """
         payload: dict[str, bool | list[str]] = {
             "skipDisabled": only_enabled,
@@ -144,6 +147,14 @@ class ViClient:
         flat_features = []
         for raw_feature in raw_features:
             flat_features.extend(parse_feature_flat(raw_feature))
+
+        feature_names_seen: set[str] = set()
+        for feature in flat_features:
+            if feature.name in feature_names_seen:
+                raise ViResponseError(
+                    f"Duplicate feature name in API response: {feature.name}"
+                )
+            feature_names_seen.add(feature.name)
 
         filtered_features = [
             feature

--- a/src/vi_api_client/models.py
+++ b/src/vi_api_client/models.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
 
 from .exceptions import ViError
@@ -15,7 +17,7 @@ class FeatureControl:
     Attributes:
         command_name: Name of the command to execute (e.g. 'setCurve').
         param_name: Name of the parameter mapping to this feature (e.g. 'slope').
-        required_params: List of all parameters required by this command.
+        required_params: Read-only parameter names required by this command.
             Used for dependency resolution (e.g. ['slope', 'shift']).
         parent_feature_name: Name of the parent feature in the API.
             Used to find sibling features during dependency resolution.
@@ -25,7 +27,7 @@ class FeatureControl:
         step: Step size (numeric constraint).
         value_type: Viessmann command parameter type, such as ``number`` or
             ``boolean``.
-        options: List of allowed values (enum constraint).
+        options: Read-only allowed values (enum constraint).
         min_length: Minimum length of string value.
         max_length: Maximum length of string value.
         pattern: Regex pattern for string validation.
@@ -33,17 +35,23 @@ class FeatureControl:
 
     command_name: str
     param_name: str
-    required_params: list[str]
+    required_params: Sequence[str]
     parent_feature_name: str
     uri: str
     min: float | None = None
     max: float | None = None
     step: float | None = None
     value_type: str | None = None
-    options: list[Any] | None = None
+    options: Sequence[Any] | None = None
     min_length: int | None = None
     max_length: int | None = None
     pattern: str | None = None
+
+    def __post_init__(self) -> None:
+        """Store caller-owned sequences as immutable snapshots."""
+        object.__setattr__(self, "required_params", tuple(self.required_params))
+        if self.options is not None:
+            object.__setattr__(self, "options", tuple(self.options))
 
 
 @dataclass(frozen=True)
@@ -83,7 +91,7 @@ class Device:
         model_id: Model identifier (e.g. 'Simple_Device').
         device_type: Type classification (e.g. 'heating').
         status: Connection status (e.g. 'Online').
-        features: List of all associated features.
+        features: Read-only associated features.
     """
 
     id: str
@@ -92,17 +100,27 @@ class Device:
     model_id: str
     device_type: str
     status: str
-    features: list[Feature] = field(default_factory=list)
+    features: Sequence[Feature] = field(default_factory=tuple)
 
     # Internal cache for O(1) lookup
-    _features_by_name: dict[str, Feature] = field(
-        init=False, repr=False, default_factory=dict
+    _features_by_name: Mapping[str, Feature] = field(
+        init=False, repr=False, default_factory=lambda: MappingProxyType({})
     )
 
     def __post_init__(self) -> None:
-        """Build internal cache."""
-        feature_map = {feature.name: feature for feature in self.features}
-        object.__setattr__(self, "_features_by_name", feature_map)
+        """Store features and their lookup cache as immutable snapshots.
+
+        Raises:
+            ValueError: If more than one feature has the same name.
+        """
+        features = tuple(self.features)
+        feature_map: dict[str, Feature] = {}
+        for feature in features:
+            if feature.name in feature_map:
+                raise ValueError(f"Duplicate feature name: {feature.name}")
+            feature_map[feature.name] = feature
+        object.__setattr__(self, "features", features)
+        object.__setattr__(self, "_features_by_name", MappingProxyType(feature_map))
 
     def get_feature(self, name: str) -> Feature | None:
         """O(1) lookup helper.
@@ -150,8 +168,17 @@ class GatewayDeviceRefreshResult:
         errors_by_device_id: Device-specific failures keyed by device ID.
     """
 
-    updated_devices: list[Device]
-    errors_by_device_id: dict[str, ViError]
+    updated_devices: Sequence[Device]
+    errors_by_device_id: Mapping[str, ViError]
+
+    def __post_init__(self) -> None:
+        """Store caller-owned collections as immutable snapshots."""
+        object.__setattr__(self, "updated_devices", tuple(self.updated_devices))
+        object.__setattr__(
+            self,
+            "errors_by_device_id",
+            MappingProxyType(dict(self.errors_by_device_id)),
+        )
 
     @property
     def is_complete(self) -> bool:
@@ -204,13 +231,17 @@ class Installation:
         id: Unique installation ID (numeric string).
         description: User-provided description.
         alias: User-provided alias.
-        address: Physical address dictionary.
+        address: Read-only physical address mapping.
     """
 
     id: str
     description: str
     alias: str
-    address: dict[str, Any] = field(default_factory=dict)
+    address: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Store caller-owned address data as an immutable snapshot."""
+        object.__setattr__(self, "address", MappingProxyType(dict(self.address)))
 
     @classmethod
     def from_api(cls, data: dict[str, Any]) -> Installation:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,7 +158,7 @@ async def test_update_gateway_devices_accepts_empty_input_without_request():
 
     # Assert: Empty input is a complete result and performs no I/O.
     assert result.is_complete
-    assert result.updated_devices == []
+    assert result.updated_devices == ()
     assert result.errors_by_device_id == {}
 
 
@@ -269,7 +269,7 @@ async def test_update_gateway_devices_falls_back_only_for_missing_devices(
     # Assert: Only the absent device uses the fallback; empty features are successful.
     assert result.is_complete
     assert [device.id for device in result.updated_devices] == ["10", "0"]
-    assert result.updated_devices[1].features == []
+    assert result.updated_devices[1].features == ()
     assert len(mock_responses.requests) == 2
     assert any(
         method == "POST" and str(request_url) == device_url
@@ -627,6 +627,33 @@ async def test_get_features(load_fixture_json):
             assert features[0].name == "heating.sensors.temperature.outside"
             assert features[0].value == 5.5
             assert features[1].name == "heating.circuits.0.active"
+
+
+@pytest.mark.asyncio
+async def test_get_features_translates_duplicate_api_feature_names(load_fixture_json):
+    # Arrange: Mock a response containing the same feature twice.
+    data = load_fixture_json("features_heating_sensors.json")
+    data["data"].append(deepcopy(data["data"][0]))
+    device = Device(
+        id="0",
+        gateway_serial="1234567890",
+        installation_id="123456",
+        model_id="test",
+        device_type="heating",
+        status="ok",
+    )
+    url = f"{API_BASE_URL}{ENDPOINT_FEATURES}/123456/gateways/1234567890/devices/0/features/filter"
+
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload=data)
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: The client translates an invalid API response.
+            with pytest.raises(ViResponseError, match="Duplicate feature name"):
+                await client.get_features(
+                    device, feature_names=["heating.circuits.0.active"]
+                )
 
 
 @pytest.mark.asyncio

--- a/tests/test_gateway_device_refresh_contract.py
+++ b/tests/test_gateway_device_refresh_contract.py
@@ -132,7 +132,7 @@ async def test_gateway_refresh_falls_back_for_omitted_devices_and_preserves_orde
     assert adapter.calls == ["gateway", "device:0"]
     assert [device.id for device in result.updated_devices] == ["10", "0"]
     assert result.updated_devices[0].model_id == "model-10"
-    assert result.updated_devices[1].features == []
+    assert result.updated_devices[1].features == ()
     assert result.is_complete
 
 

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -41,7 +41,7 @@ async def test_mock_update_device_returns_hydrated_copy_without_mutating_input()
     refreshed_device = await client.update_device(device)
 
     # Assert: The input remains unhydrated and the returned copy has features.
-    assert device.features == []
+    assert device.features == ()
     assert refreshed_device is not device
     assert refreshed_device.features
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,9 @@
 """Tests for data models (Flat Architecture)."""
 
+from collections.abc import Mapping, Sequence
+
+import pytest
+
 import vi_api_client
 from vi_api_client.exceptions import ViError, ViResponseError
 from vi_api_client.models import (
@@ -7,6 +11,7 @@ from vi_api_client.models import (
     Feature,
     FeatureControl,
     GatewayDeviceRefreshResult,
+    Installation,
 )
 
 
@@ -25,6 +30,20 @@ def test_feature_dataclass():
     assert feature.value == 10
     assert feature.unit == "C"
     assert feature.is_writable is False
+
+
+def test_feature_value_is_not_recursively_frozen():
+    # Arrange: Create a feature with a caller-owned arbitrary payload.
+    value = {"entries": [1]}
+    feature = Feature(
+        name="test.feature", value=value, unit=None, is_enabled=True, is_ready=True
+    )
+
+    # Act: Mutate the arbitrary value after construction.
+    value["entries"].append(2)
+
+    # Assert: The model collection contract does not recursively freeze Any values.
+    assert feature.value == {"entries": [1, 2]}
 
 
 def test_feature_writable():
@@ -59,7 +78,7 @@ def test_feature_writable():
     assert feature.control.min == 0
     assert feature.control.max == 100
     assert feature.control.value_type == "number"
-    assert feature.control.options == [1, 2]
+    assert feature.control.options == (1, 2)
 
 
 def test_device_dataclass():
@@ -85,6 +104,98 @@ def test_device_dataclass():
     assert dev.get_feature("f1") == f1
     assert dev.get_feature("f2") == f2
     assert dev.get_feature("missing") is None
+
+
+def test_device_features_are_immutable_and_keep_lookup_in_sync():
+    # Arrange: Build a device from a caller-owned mutable feature list.
+    first_feature = Feature(
+        name="f1", value=1, unit=None, is_enabled=True, is_ready=True
+    )
+    second_feature = Feature(
+        name="f2", value=2, unit=None, is_enabled=True, is_ready=True
+    )
+    input_features = [first_feature]
+    device = Device(
+        id="123",
+        gateway_serial="gw",
+        installation_id="inst",
+        model_id="TestModel",
+        device_type="test",
+        status="Online",
+        features=input_features,
+    )
+
+    # Act: Mutate the caller-owned collection after construction.
+    input_features.append(second_feature)
+
+    # Assert: The snapshot and its O(1) lookup remain consistent and read-only.
+    assert isinstance(device.features, Sequence)
+    assert not isinstance(device.features, list)
+    assert device.features == (first_feature,)
+    assert device.get_feature("f1") is first_feature
+    assert device.get_feature("f2") is None
+    assert isinstance(device._features_by_name, Mapping)
+    cache_attribute = "_features_by_name"
+    with pytest.raises(TypeError):
+        getattr(device, cache_attribute)["f2"] = second_feature
+
+
+def test_device_rejects_duplicate_feature_names():
+    # Arrange: Build two distinct features with the same documented identity.
+    duplicate_features = [
+        Feature(name="f1", value=1, unit=None, is_enabled=True, is_ready=True),
+        Feature(name="f1", value=2, unit=None, is_enabled=True, is_ready=True),
+    ]
+
+    # Act and assert: Direct invalid model construction is rejected.
+    with pytest.raises(ValueError, match="Duplicate feature name: f1"):
+        Device(
+            id="123",
+            gateway_serial="gw",
+            installation_id="inst",
+            model_id="TestModel",
+            device_type="test",
+            status="Online",
+            features=duplicate_features,
+        )
+
+
+def test_other_model_collections_are_immutable_snapshots():
+    # Arrange: Create models from caller-owned mutable collections.
+    required_params = ["target"]
+    options = ["eco"]
+    control = FeatureControl(
+        command_name="set",
+        param_name="target",
+        required_params=required_params,
+        parent_feature_name="parent",
+        uri="url",
+        options=options,
+    )
+    refreshed_devices = []
+    errors_by_device_id = {"device-1": ViError("unavailable")}
+    result = GatewayDeviceRefreshResult(refreshed_devices, errors_by_device_id)
+    address = {"city": "Berlin"}
+    installation = Installation("1", "Home", "Home", address)
+
+    # Act: Mutate the original collections after construction.
+    required_params.append("mode")
+    options.append("comfort")
+    refreshed_devices.append(Device("1", "gw", "inst", "model", "heating", "connected"))
+    errors_by_device_id["device-2"] = ViError("offline")
+    address["street"] = "Example Street"
+
+    # Assert: Each public collection is an immutable defensive copy.
+    assert control.required_params == ("target",)
+    assert control.options == ("eco",)
+    assert result.updated_devices == ()
+    assert list(result.errors_by_device_id) == ["device-1"]
+    assert installation.address == {"city": "Berlin"}
+    for collection in (result.errors_by_device_id, installation.address):
+        assert isinstance(collection, Mapping)
+        setitem_method = "__setitem__"
+        with pytest.raises((AttributeError, TypeError)):
+            getattr(collection, setitem_method)("changed", "value")
 
 
 def test_device_from_api():


### PR DESCRIPTION
## Summary
- store model-owned sequences and mappings as read-only defensive snapshots
- keep Device feature lookup consistent and reject duplicate feature identities
- translate duplicate API feature names to ViResponseError

## Validation
- ruff check .
- ruff format --check .
- pytest -q (173 passed)
- pyright --pythonpath .venv/bin/python

Closes #64