### PR TITLE
Build distribution artifacts in quality gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,14 @@ python -m pip install --upgrade pip
 python -m pip install -c constraints-ci.txt '.[dev]'
 ruff check .
 ruff format --check .
+pyright --pythonpath python
 python -m pytest -q
+python -m build
 ```
 
-Run `python -m build` as well when changing packaging metadata, build configuration, dependencies, or CLI entry points. `constraints-ci.txt` defines the CI-tested HTTP-client and mock combination.
+The quality gate builds both distribution artifacts after linting, formatting,
+type checking, and tests. `constraints-ci.txt` defines the CI-tested HTTP-client
+and mock combination.
 
 ## Git, Pull Requests, and Releases
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ruff check .
 ruff format --check .
 pyright --pythonpath python
 python -m pytest -q
+python -m build
 ```
 
 ## Quick Start

--- a/scripts/quality_check.py
+++ b/scripts/quality_check.py
@@ -13,6 +13,7 @@ COMMANDS = (
     (sys.executable, "-m", "ruff", "format", "--check", "."),
     (sys.executable, "-m", "pyright", "--pythonpath", sys.executable),
     (sys.executable, "-m", "pytest", "-q"),
+    (sys.executable, "-m", "build"),
 )
 
 


### PR DESCRIPTION
## Summary
- Run `python -m build` through the normal quality gate for pull requests and main pushes.
- Retain the tagged-release build from the tagged commit.
- Document the complete local quality gate.

## Validation
- `.venv/bin/python scripts/quality_check.py`
- Verified 8 bundled fixture JSON files in both sdist and wheel.

Closes #65