### PR TITLE
fix(cli): keep JSON output machine-readable

### DIFF
--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -50,6 +50,9 @@ vi-client list-features --enabled --values
 # Output as JSON
 vi-client list-features --json
 ```
+JSON output writes one parseable document to standard output; setup diagnostics
+and warnings are written to standard error.
+
 *Note: This auto-detects the first device. You can specify `--gateway-serial` and `--device-id` if needed.*
 *Note: For `heating.power.consumption.{cooling,dhw,heating,total}`, the flattened feature list may include one synthetic `...currentYear` alias per base feature. `currentDay` and `currentMonth` aliases are not generated.*
 

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -35,6 +35,11 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 _LOGGER = logging.getLogger(__name__)
 
 
+def _print_diagnostic(args, message: str) -> None:
+    """Print setup information without contaminating requested JSON output."""
+    print(message, file=sys.stderr if getattr(args, "json", False) else sys.stdout)
+
+
 @dataclass
 class CLIContext:
     """Context for CLI commands."""
@@ -57,7 +62,7 @@ async def create_session(args) -> aiohttp.ClientSession:
         An aiohttp ClientSession configured according to args.
     """
     if args.insecure:
-        print("WARNING: SSL verification disabled via --insecure")
+        _print_diagnostic(args, "WARNING: SSL verification disabled via --insecure")
         connector = aiohttp.TCPConnector(ssl=False)
         return aiohttp.ClientSession(connector=connector)
     return aiohttp.ClientSession()
@@ -106,11 +111,12 @@ def get_client_config(args) -> tuple[str, str]:
     )
 
     if not client_id:
-        print(
+        _print_diagnostic(
+            args,
             "Error: Client ID not found. Provide via --client-id or "
-            "VIESSMANN_CLIENT_ID env var."
+            "VIESSMANN_CLIENT_ID env var.",
         )
-        print("Please run 'login' first or provide --client-id.")
+        _print_diagnostic(args, "Please run 'login' first or provide --client-id.")
         sys.exit(1)
 
     return client_id, redirect_uri
@@ -126,7 +132,7 @@ async def setup_client_context(
         inst_id = getattr(args, "installation_id", None) or "99999"
         gw_serial = getattr(args, "gateway_serial", None) or "MOCK_GATEWAY"
         dev_id = getattr(args, "device_id", None) or "0"
-        print(f"Using Mock Device: {args.mock_device}")
+        _print_diagnostic(args, f"Using Mock Device: {args.mock_device}")
         yield CLIContext(None, client, inst_id, gw_serial, dev_id)
         return
 
@@ -144,7 +150,7 @@ async def setup_client_context(
         if discover and not (inst_id and gw_serial and dev_id):
             gateways = await client.get_gateways()
             if not gateways:
-                print("No gateways found.")
+                _print_diagnostic(args, "No gateways found.")
                 raise ValueError("No gateways found.")
 
             if gw_serial:
@@ -187,9 +193,10 @@ async def setup_client_context(
                     devices[0],
                 )
                 dev_id = target_dev.id
-                print(
+                _print_diagnostic(
+                    args,
                     f"Auto-selected Context: Inst={inst_id}, GW={gw_serial}, "
-                    f"Dev={dev_id}"
+                    f"Dev={dev_id}",
                 )
 
         if not (inst_id and gw_serial and dev_id):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -607,6 +607,85 @@ async def test_cmd_list_features_json(mock_cli_context, capsys):
 
 
 @pytest.mark.asyncio
+async def test_async_main_json_output_with_mock_device_is_machine_readable(
+    monkeypatch, capsys
+):
+    """The real CLI path must reserve stdout for a JSON feature list."""
+    # Arrange: Use a bundled fixture without replacing client context setup.
+    monkeypatch.setattr(
+        "sys.argv",
+        ["vi-client", "list-features", "--mock-device", "Vitocal250A", "--json"],
+    )
+
+    # Act: Invoke the parser, dispatcher, and context setup through the CLI entry path.
+    exit_status = await async_main()
+
+    # Assert: JSON output is parseable and setup diagnostics stay on stderr.
+    captured = capsys.readouterr()
+    assert exit_status == 0
+    assert json.loads(captured.out)
+    assert "Using Mock Device: Vitocal250A" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_async_main_json_feature_values_with_mock_device_are_machine_readable(
+    monkeypatch, capsys
+):
+    """The real CLI path must reserve stdout for JSON feature values."""
+    # Arrange: Use a bundled fixture without replacing client context setup.
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "vi-client",
+            "list-features",
+            "--mock-device",
+            "Vitocal250A",
+            "--values",
+            "--json",
+        ],
+    )
+
+    # Act: Invoke the parser, dispatcher, and context setup through the CLI entry path.
+    exit_status = await async_main()
+
+    # Assert: JSON output includes values and setup diagnostics stay on stderr.
+    captured = capsys.readouterr()
+    assert exit_status == 0
+    features = json.loads(captured.out)
+    assert features
+    assert all("value" in feature for feature in features)
+    assert "Using Mock Device: Vitocal250A" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_async_main_json_setup_error_is_written_to_stderr(
+    monkeypatch, capsys, tmp_path
+):
+    """A JSON-mode setup error must preserve stdout for a payload document."""
+    # Arrange: Request live JSON output without saved or explicit credentials.
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "vi-client",
+            "list-features",
+            "--json",
+            "--token-file",
+            str(tmp_path / "tokens.json"),
+        ],
+    )
+
+    # Act: Invoke the CLI entry path.
+    with pytest.raises(SystemExit) as error:
+        await async_main()
+
+    # Assert: The failed setup leaves stdout empty and preserves the diagnostic.
+    captured = capsys.readouterr()
+    assert error.value.code == 1
+    assert captured.out == ""
+    assert "Error: Client ID not found." in captured.err
+
+
+@pytest.mark.asyncio
 async def test_cmd_list_features_enabled(mock_cli_context, capsys):
     """Test listing only enabled features (should use only_enabled=True)."""
     # Arrange: Create mock client, device, and fixture data for test.

--- a/tests/test_cli_context.py
+++ b/tests/test_cli_context.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from vi_api_client.cli import CLIContext, setup_client_context
+from vi_api_client.cli import CLIContext, create_session, setup_client_context
 from vi_api_client.models import Device, Gateway
 
 
@@ -83,7 +83,9 @@ async def test_cli_context_explicit_ids():
 
 
 @pytest.mark.asyncio
-async def test_cli_context_autodiscovery(tmp_path):
+async def test_cli_context_autodiscovery_routes_context_to_stderr_for_json(
+    tmp_path, capsys
+):
     """Test CLI context auto-discovery by mocking the Client completely."""
     # Arrange: Create mock client, device, and fixture data for test.
     args = Namespace(
@@ -95,6 +97,7 @@ async def test_cli_context_autodiscovery(tmp_path):
         installation_id=None,
         gateway_serial=None,
         device_id=None,
+        json=True,
     )
 
     # We patch Client so we don't need real Auth or Network
@@ -135,6 +138,27 @@ async def test_cli_context_autodiscovery(tmp_path):
             # Verify client method calls
             mock_client.get_gateways.assert_called_once()
             mock_client.get_devices.assert_called_once_with("100", "GW123")
+
+    # Assert: JSON output callers receive setup context as a diagnostic.
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Auto-selected Context: Inst=100, GW=GW123, Dev=0" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_cli_context_routes_insecure_warning_to_stderr_for_json(capsys):
+    """Insecure TLS warnings must not contaminate requested JSON output."""
+    # Arrange: Request JSON output while disabling TLS verification.
+    args = Namespace(insecure=True, json=True)
+
+    # Act: Create and close the session without making a network request.
+    session = await create_session(args)
+    await session.close()
+
+    # Assert: The warning remains a visible stderr diagnostic.
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "WARNING: SSL verification disabled via --insecure" in captured.err
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep JSON CLI stdout limited to the payload
- send mock, autodiscovery, TLS, and setup diagnostics to stderr
- add real CLI-path regression coverage using bundled fixtures

## Validation
- pyright
- ruff check and format
- pytest (177 passed)
- python -m build

Closes #66