### PR TITLE
fix(api): reject malformed discovery responses

### DIFF
--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -91,7 +91,7 @@ class ViClient:
         )
         devices = [
             Device.from_api(device_data, gateway_serial, installation_id)
-            for device_data in devices_data.get("data", [])
+            for device_data in self._get_discovery_data(devices_data, "Device")
         ]
 
         if include_features:
@@ -142,7 +142,7 @@ class ViClient:
             only_enabled,
         )
         response = await self._discovery_adapter.get_features(device, payload)
-        raw_features = response.get("data", [])
+        raw_features = self._get_discovery_data(response, "Feature")
 
         flat_features = []
         for raw_feature in raw_features:
@@ -370,10 +370,12 @@ class ViClient:
         if not isinstance(envelope, dict):
             raise ViResponseError(f"{resource_name} response must be an object")
         data = envelope.get("data")
-        if not isinstance(data, list) or not all(
-            isinstance(item, dict) for item in data
-        ):
+        if not isinstance(data, list):
             raise ViResponseError(f"{resource_name} response data must be a list")
+        if not all(isinstance(item, dict) for item in data):
+            raise ViResponseError(
+                f"{resource_name} response data entries must be objects"
+            )
         return data
 
     async def _execute_command(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -457,48 +457,79 @@ async def test_get_gateways(load_fixture_json):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("endpoint", "method"),
+    ("url", "request_method", "operation", "arguments"),
     [
-        (ENDPOINT_INSTALLATIONS, "get_installations"),
-        (ENDPOINT_GATEWAYS, "get_gateways"),
+        (f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}", "get", "get_installations", ()),
+        (f"{API_BASE_URL}{ENDPOINT_GATEWAYS}", "get", "get_gateways", ()),
+        (
+            f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}/installation-1/gateways/gateway-1/devices",
+            "get",
+            "get_devices",
+            ("installation-1", "gateway-1"),
+        ),
+        (
+            f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/gateway-1/devices/0/features/filter",
+            "post",
+            "get_features",
+            (_build_gateway_device("0"),),
+        ),
     ],
 )
-async def test_discovery_rejects_successful_non_json_responses(endpoint, method):
+async def test_discovery_rejects_successful_non_json_responses(
+    url, request_method, operation, arguments
+):
     """Discovery should reject successful responses that are not JSON objects."""
     # Arrange: Return non-JSON content from each discovery endpoint.
-    url = f"{API_BASE_URL}{endpoint}"
-
     with aioresponses() as mock_responses:
-        mock_responses.get(url, body="not JSON", content_type="text/plain")
+        getattr(mock_responses, request_method)(
+            url, body="not JSON", content_type="text/plain"
+        )
         async with aiohttp.ClientSession() as session:
             client = ViClient(MockAuth(session))
 
             # Act and assert: The public response error communicates the contract failure.
             with pytest.raises(ViResponseError):
-                await getattr(client, method)()
+                await getattr(client, operation)(*arguments)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("endpoint", "method"),
+    ("url", "request_method", "operation", "arguments"),
     [
-        (ENDPOINT_INSTALLATIONS, "get_installations"),
-        (ENDPOINT_GATEWAYS, "get_gateways"),
+        (f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}", "get", "get_installations", ()),
+        (f"{API_BASE_URL}{ENDPOINT_GATEWAYS}", "get", "get_gateways", ()),
+        (
+            f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}/installation-1/gateways/gateway-1/devices",
+            "get",
+            "get_devices",
+            ("installation-1", "gateway-1"),
+        ),
+        (
+            f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/gateway-1/devices/0/features/filter",
+            "post",
+            "get_features",
+            (_build_gateway_device("0"),),
+        ),
     ],
 )
-async def test_discovery_rejects_successful_malformed_json_envelopes(endpoint, method):
+@pytest.mark.parametrize(
+    "response",
+    [[], {}, {"data": {}}, {"data": [None]}],
+    ids=["root-list", "missing-data", "data-not-list", "data-entry-not-object"],
+)
+async def test_discovery_rejects_successful_malformed_json_envelopes(
+    url, request_method, operation, arguments, response
+):
     """Discovery should reject successful JSON that violates its envelope contract."""
-    # Arrange: Return a JSON object whose data member is not a collection.
-    url = f"{API_BASE_URL}{endpoint}"
-
+    # Arrange: Return JSON that violates a collection envelope requirement.
     with aioresponses() as mock_responses:
-        mock_responses.get(url, payload={"data": {}})
+        getattr(mock_responses, request_method)(url, payload=response)
         async with aiohttp.ClientSession() as session:
             client = ViClient(MockAuth(session))
 
             # Act and assert: The public response error communicates the contract failure.
             with pytest.raises(ViResponseError):
-                await getattr(client, method)()
+                await getattr(client, operation)(*arguments)
 
 
 @pytest.mark.asyncio
@@ -567,6 +598,40 @@ async def test_get_full_installation_status_uses_matching_gateways_only():
     assert devices == []
     assert devices_url in requested_urls
     assert other_gateway not in "".join(requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_get_full_installation_status_rejects_malformed_device_responses():
+    """Full status should preserve discovery envelope validation."""
+    # Arrange: Return a matching gateway followed by invalid device collection entries.
+    installation_id = "installation-1"
+    gateway_serial = "gateway-1"
+    gateways_url = f"{API_BASE_URL}{ENDPOINT_GATEWAYS}"
+    devices_url = (
+        f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}/{installation_id}/gateways/"
+        f"{gateway_serial}/devices"
+    )
+    with aioresponses() as mock_responses:
+        mock_responses.get(
+            gateways_url,
+            payload={
+                "data": [
+                    {
+                        "installationId": installation_id,
+                        "serial": gateway_serial,
+                        "status": "connected",
+                        "version": "1.0.0",
+                    }
+                ]
+            },
+        )
+        mock_responses.get(devices_url, payload={"data": [None]})
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: The composed read keeps the public response error.
+            with pytest.raises(ViResponseError, match="entries must be objects"):
+                await client.get_full_installation_status(installation_id)
 
 
 @pytest.mark.asyncio
@@ -789,6 +854,25 @@ async def test_update_device(load_fixture_json):
             assert updated_dev.id == "0"
             assert len(updated_dev.features) == 1
             assert updated_dev.features[0].name == "new.feature"
+
+
+@pytest.mark.asyncio
+async def test_update_device_rejects_malformed_feature_responses():
+    """Device refresh should preserve feature envelope validation."""
+    # Arrange: Return an invalid feature collection for an existing device.
+    device = _build_gateway_device("0")
+    url = (
+        f"{API_BASE_URL}{ENDPOINT_FEATURES}/installation-1/gateways/"
+        "gateway-1/devices/0/features/filter"
+    )
+    with aioresponses() as mock_responses:
+        mock_responses.post(url, payload={"data": [None]})
+        async with aiohttp.ClientSession() as session:
+            client = ViClient(MockAuth(session))
+
+            # Act and assert: The composed refresh keeps the public response error.
+            with pytest.raises(ViResponseError, match="entries must be objects"):
+                await client.update_device(device)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -3,6 +3,8 @@
 import pytest
 
 from vi_api_client import MockViClient
+from vi_api_client.exceptions import ViResponseError
+from vi_api_client.mock_client import _FixtureDiscoveryAdapter
 
 
 def test_mock_client_rejects_obsolete_authentication_argument():
@@ -82,6 +84,21 @@ async def test_mock_feature_filters_apply_shared_enabled_and_name_semantics():
 
     # Assert: Shared filtering retains the requested enabled and ready feature only.
     assert [feature.name for feature in features] == ["device.serial"]
+
+
+@pytest.mark.asyncio
+async def test_mock_client_rejects_malformed_fixture_feature_envelopes():
+    """Fixture feature responses should use the same envelope validation as live ones."""
+    # Arrange: Replace the cached fixture response with an invalid collection entry.
+    client = MockViClient("Vitodens200W")
+    device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
+    fixture_adapter = client._discovery_adapter
+    assert isinstance(fixture_adapter, _FixtureDiscoveryAdapter)
+    fixture_adapter._feature_data = {"data": [None]}
+
+    # Act and assert: The inherited public feature read exposes ViResponseError.
+    with pytest.raises(ViResponseError, match="entries must be objects"):
+        await client.get_features(device)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate device and feature discovery envelopes through the shared client boundary
- raise ViResponseError for malformed successful collections across live and fixture-backed clients
- cover malformed primary and composite reads

## Validation
- ruff check .
- ruff format --check .
- pyright --pythonpath .venv/bin/python
- pytest -q
- python -m build

Closes #67