### PR TITLE
feat(api): curate package-root public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,42 @@ Designed for integration with Home Assistant and other async Python applications
 - **Mock Client**: Runs the same client workflows against bundled real-device
   responses without authentication, sessions, or network requests.
 
+## Public API
+
+Import consumer-facing symbols from `vi_api_client`:
+
+```python
+from vi_api_client import (
+    AbstractAuth,
+    CommandResponse,
+    DEFAULT_SCOPES,
+    Device,
+    ENDPOINT_AUTHORIZE,
+    ENDPOINT_TOKEN,
+    Feature,
+    FeatureControl,
+    Gateway,
+    GatewayDeviceRefreshResult,
+    Installation,
+    MockViClient,
+    OAuth,
+    ViAuthError,
+    ViClient,
+    ViConnectionError,
+    ViError,
+    ViNotFoundError,
+    ViRateLimitError,
+    ViResponseError,
+    ViServerInternalError,
+    ViValidationError,
+    format_feature,
+)
+```
+
+`DEFAULT_SCOPES`, `ENDPOINT_AUTHORIZE`, and `ENDPOINT_TOKEN` support external
+OAuth integrations. CLI helpers, transport details, persistence, parsing, and
+utilities such as `mask_pii` remain available from their dedicated modules.
+
 ## Installation
 
 This is currently a local development package. **Requires Python 3.14+**.

--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -59,6 +59,13 @@ while sending the authenticated API request are exposed as `ViConnectionError`.
 
 Implements the OAuth2 PKCE flow (Proof Key for Code Exchange). This is the standard flow for Viessmann API.
 
+External OAuth integrations can import the default scope and authorization
+endpoints from the package root:
+
+```python
+from vi_api_client import DEFAULT_SCOPES, ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
+```
+
 ```python
 from vi_api_client import OAuth
 ```

--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -2,6 +2,21 @@
 
 This section details the core data models used in the `vi_api_client` library.
 
+Import public models and helpers from the package root:
+
+```python
+from vi_api_client import (
+    CommandResponse,
+    Device,
+    Feature,
+    FeatureControl,
+    Gateway,
+    GatewayDeviceRefreshResult,
+    Installation,
+    format_feature,
+)
+```
+
 ## Installation
 
 Represents an installation site (House).
@@ -59,7 +74,7 @@ The core unit of information. A feature represents a single property (Sensor) or
 To format a feature value for display with units:
 
 ```python
-from vi_api_client.utils import format_feature
+from vi_api_client import format_feature
 
 print(format_feature(feature))  # "25.5 celsius"
 ```

--- a/docs/07_exceptions_reference.md
+++ b/docs/07_exceptions_reference.md
@@ -4,6 +4,21 @@ The library simplifies Viessmann API error handling by mapping HTTP status codes
 
 All exceptions inherit from `ViError` (and `Exception`).
 
+Import exception classes from the package root:
+
+```python
+from vi_api_client import (
+    ViAuthError,
+    ViConnectionError,
+    ViError,
+    ViNotFoundError,
+    ViRateLimitError,
+    ViResponseError,
+    ViServerInternalError,
+    ViValidationError,
+)
+```
+
 ## Exception Hierarchy
 
 *   `ViError` (Base class)

--- a/src/vi_api_client/__init__.py
+++ b/src/vi_api_client/__init__.py
@@ -2,6 +2,7 @@
 
 from .api import ViClient
 from .auth import AbstractAuth, OAuth
+from .const import DEFAULT_SCOPES, ENDPOINT_AUTHORIZE, ENDPOINT_TOKEN
 from .exceptions import (
     ViAuthError,
     ViConnectionError,
@@ -13,14 +14,29 @@ from .exceptions import (
     ViValidationError,
 )
 from .mock_client import MockViClient
-from .models import Device, Feature, GatewayDeviceRefreshResult
-from .utils import mask_pii
+from .models import (
+    CommandResponse,
+    Device,
+    Feature,
+    FeatureControl,
+    Gateway,
+    GatewayDeviceRefreshResult,
+    Installation,
+)
+from .utils import format_feature
 
 __all__ = [
+    "DEFAULT_SCOPES",
+    "ENDPOINT_AUTHORIZE",
+    "ENDPOINT_TOKEN",
     "AbstractAuth",
+    "CommandResponse",
     "Device",
     "Feature",
+    "FeatureControl",
+    "Gateway",
     "GatewayDeviceRefreshResult",
+    "Installation",
     "MockViClient",
     "OAuth",
     "ViAuthError",
@@ -32,5 +48,5 @@ __all__ = [
     "ViResponseError",
     "ViServerInternalError",
     "ViValidationError",
-    "mask_pii",
+    "format_feature",
 ]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,55 @@
+"""Contract tests for the consumer-facing package-root API."""
+
+import vi_api_client
+from vi_api_client.utils import mask_pii
+
+
+def test_package_root_exposes_only_the_documented_consumer_api():
+    """Package-root exports should match the supported consumer API exactly."""
+    expected_exports = {
+        "AbstractAuth",
+        "CommandResponse",
+        "DEFAULT_SCOPES",
+        "Device",
+        "ENDPOINT_AUTHORIZE",
+        "ENDPOINT_TOKEN",
+        "Feature",
+        "FeatureControl",
+        "Gateway",
+        "GatewayDeviceRefreshResult",
+        "Installation",
+        "MockViClient",
+        "OAuth",
+        "ViAuthError",
+        "ViClient",
+        "ViConnectionError",
+        "ViError",
+        "ViNotFoundError",
+        "ViRateLimitError",
+        "ViResponseError",
+        "ViServerInternalError",
+        "ViValidationError",
+        "format_feature",
+    }
+
+    assert set(vi_api_client.__all__) == expected_exports
+    assert all(hasattr(vi_api_client, export) for export in expected_exports)
+
+
+def test_package_root_hides_technical_helpers_but_preserves_utility_imports():
+    """Technical helpers should stay in their existing modules, not the root API."""
+    non_public_exports = {
+        "API_BASE_URL",
+        "AUTH_BASE_URL",
+        "ENDPOINT_FEATURES",
+        "ENDPOINT_GATEWAYS",
+        "ENDPOINT_INSTALLATIONS",
+        "SCOPE_IOT_USER",
+        "SCOPE_OFFLINE_ACCESS",
+        "mask_pii",
+        "parse_cli_params",
+        "parse_feature_flat",
+    }
+
+    assert all(not hasattr(vi_api_client, export) for export in non_public_exports)
+    assert mask_pii("Authorization: Bearer secret") == "Authorization: Bearer ***"


### PR DESCRIPTION
## Summary

- Curate the documented consumer-facing package-root exports
- Add exact package-root API contract coverage
- Update README and user-facing references to use root imports

Closes #68

## Validation

- ruff check .
- ruff format --check .
- pyright --pythonpath .venv/bin/python
- python -m pytest -q
- python -m build