### PR TITLE
docs: define canonical client domain language

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,3 +24,47 @@ _Avoid_: Gateway feature fetch
 A device feature that is both enabled by the device configuration and ready for
 interaction at the time it is retrieved.
 _Avoid_: Active feature
+
+**Device snapshot**:
+The immutable representation of a device and the features known when that
+snapshot was created. An empty feature collection does not reveal whether no
+feature response has been applied or whether the response contained no
+features.
+_Avoid_: Hydrated device
+
+**Device feature hydration**:
+The operation of producing a new device snapshot from a feature response. It
+is an operation, not an observable device state.
+_Avoid_: Device hydration state
+
+**Refreshed device snapshot**:
+A device snapshot whose feature values came from an API read response.
+
+**Command-updated device snapshot**:
+A device snapshot updated locally after a successful feature command response,
+without a subsequent API read-back.
+_Avoid_: Optimistic update
+
+**Feature**:
+One flat, addressable device property with its reported value and capabilities.
+
+**Writable feature**:
+A feature that reports `is_writable=True` and has `FeatureControl` metadata
+describing how a feature command can target it.
+
+**Feature command**:
+The API operation that sends command parameters for a writable feature.
+`FeatureControl` is the existing Python class name for command metadata; it is
+not the executed command.
+
+**Live client**:
+`ViClient` configured with authentication that reads from the Viessmann API.
+
+**Fixture-backed client**:
+`MockViClient`, which runs the public client workflows against bundled fixture
+responses without authentication or network requests.
+
+**Credential document**:
+The JSON file shared by OAuth token persistence and CLI authentication
+configuration. A missing document is empty; a corrupted document raises an
+error and is neither treated as empty nor silently overwritten.

--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -42,6 +42,10 @@ Represents a communication gateway (Connectivity Device).
 ## Device
 
 Represents a physical device attached to a gateway (e.g. Heating System).
+Each `Device` is a device snapshot: an immutable representation of the device
+and the features known when it was created. A snapshot with no features does
+not indicate whether device feature hydration has occurred, because an API
+feature response can validly be empty.
 
 | Property | Type | Description | Example |
 | :--- | :--- | :--- | :--- |
@@ -57,7 +61,9 @@ Represents a physical device attached to a gateway (e.g. Heating System).
 
 ## Feature
 
-The core unit of information. A feature represents a single property (Sensor) or a single setting (Control).
+A feature is one flat, addressable device property with its reported value and
+capabilities. A writable feature reports `is_writable=True` and has
+`FeatureControl` metadata describing how a feature command can target it.
 
 | Property | Type | Description | Example |
 | :--- | :--- | :--- | :--- |
@@ -81,7 +87,9 @@ print(format_feature(feature))  # "25.5 celsius"
 
 ## FeatureControl
 
-If a `Feature` is writable (`is_writable=True`), it contains a `control` object describing how to modify it.
+If a `Feature` is writable (`is_writable=True`), it contains `FeatureControl`
+command metadata describing how a feature command can modify it. `FeatureControl`
+is not an executed command.
 
 This object abstracts away the complexity of Viessmann Commands. You rarely interact with it directly, but it's useful for introspection (e.g. building a UI).
 
@@ -116,7 +124,7 @@ and as the first element of the tuple returned by `set_feature`.
 ```python
 response, updated_device = await client.set_feature(device, feature, value)
 if response.success:
-    # Command succeeded, device is optimistically updated
+    # Command succeeded; this is a command-updated device snapshot.
     pass
 ```
 

--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -25,9 +25,10 @@ already known.
 An application that supplies `OAuth(websession=session)` owns and closes that
 session. An `AbstractAuth` provider closes only a session it created itself.
 
-`MockViClient(device_name)` is a `ViClient` subtype backed by bundled device
-responses. It supports the same high-level methods without constructing
-authentication, sessions, or network transports.
+`ViClient` is the live client when configured with authentication: its public
+workflows read from the Viessmann API. `MockViClient(device_name)` is the
+fixture-backed client: it runs those public workflows against bundled fixture
+responses without authentication or network requests.
 
 ## Discovery Methods
 
@@ -47,17 +48,19 @@ Fetches devices attached to a specific gateway.
 *   **Parameters**:
     *   `installation_id`: Installation ID (string).
     *   `gateway_serial`: Gateway serial number.
-    *   `include_features`: If `True`, automatically populates the `features` list (Default `False`).
+    *   `include_features`: If `True`, performs device feature hydration (Default `False`).
     *   `only_active_features`: If `include_features=True`, only returns enabled and ready features (Default `False`).
-*   **Returns**: List of `Device` objects. If `include_features=True`, the `features` property will be populated.
+*   **Returns**: List of device snapshots. If `include_features=True`, device
+    feature hydration produces new snapshots from the feature responses.
 
 ### `get_full_installation_status(installation_id: str, only_enabled: bool = True) -> list[Device]`
-Fetches the complete status of an installation, including all devices and their features.
+Fetches the complete status of an installation as refreshed device snapshots.
 
 *   **Parameters**:
     *   `installation_id`: The ID of the installation to scan.
     *   `only_enabled`: if `True` (default), only returns enabled and ready features.
-*   **Returns**: List of `Device` objects, where each device has its `features` attribute fully populated.
+*   **Returns**: List of refreshed device snapshots whose features came from API
+    read responses.
 *   **Use Case**: Initial startup (e.g., Home Assistant integration load) to populate the entire entity registry at once.
 
 ## Feature Methods
@@ -80,7 +83,7 @@ Refreshes a specific device by refetching all its features.
 *   **Parameters**:
     *   `device`: The `Device` object to update.
     *   `only_enabled`: if `True`, only returns enabled and ready features (default `True`).
-*   **Returns**: A new `Device` instance with updated features.
+*   **Returns**: A refreshed device snapshot with features from an API read response.
 *   **Best for**: Efficient polling. Use this instead of re-discovering the entire installation hierarchy if you already have a `Device` object.
 
 ### `update_gateway_devices(devices: list[Device]) -> GatewayDeviceRefreshResult`
@@ -113,7 +116,8 @@ for device_id, error in result.errors_by_device_id.items():
 semantics rather than this gateway-scoped partial-result contract.
 
 ### `set_feature(device: Device, feature: Feature, target_value: Any) -> tuple[CommandResponse, Device]`
-Sets a new value for a writable feature and returns an optimistically updated device.
+Sends a feature command for a writable feature and returns a command-updated
+device snapshot after a successful command response, without an API read-back.
 
 *   **Parameters**:
     *   `device`: The `Device` object.
@@ -121,7 +125,8 @@ Sets a new value for a writable feature and returns an optimistically updated de
     *   `target_value`: The new value you want to set.
 *   **Returns**: Tuple of `(CommandResponse, Device)`:
     *   `CommandResponse`: Object with `success`, `message`, and `reason` fields.
-    *   `Device`: Updated device with the feature value optimistically set (on success) or unchanged (on failure).
+    *   `Device`: Command-updated device snapshot with the feature value set
+        locally on success, or the original snapshot on failure.
 *   **Raises**:
     *   `ValueError` if the feature is read-only or the value violates client-side constraints.
     *   `ViValidationError` if the API rejects the generated command payload.

--- a/docs/06_cli_reference.md
+++ b/docs/06_cli_reference.md
@@ -96,7 +96,7 @@ vi-client exec heating.circuits.0.heating.curve setCurve slope=1.4 shift=0
 ```
 
 `exec` sends every supplied parameter as one explicit command. It does not add
-dependent values or optimistically update a device; use `set` for the normal
+dependent values or create a command-updated device snapshot; use `set` for the normal
 single-feature workflow.
 
 ## 8. Mock Devices (Offline Mode)

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -84,7 +84,8 @@ class ViClient:
             only_active_features: If include_features is True, fetch only enabled ones.
 
         Returns:
-            List of Device objects (populated with features if requested).
+            Device snapshots. When requested, device feature hydration produces
+            new snapshots from the feature responses.
         """
         devices_data = await self._discovery_adapter.get_devices(
             installation_id, gateway_serial
@@ -200,14 +201,14 @@ class ViClient:
         return all_devices
 
     async def update_device(self, device: Device, only_enabled: bool = True) -> Device:
-        """Refresh the features of an existing device.
+        """Return a refreshed device snapshot from an API feature read.
 
         Args:
             device: The device object to refresh.
             only_enabled: Whether to fetch only enabled features.
 
         Returns:
-            A new Device instance with updated features (immutable update).
+            A refreshed device snapshot with features from the API response.
         """
         features = await self.get_features(device, only_enabled=only_enabled)
         return replace(device, features=features)
@@ -280,7 +281,7 @@ class ViClient:
     async def set_feature(
         self, device: Device, feature: Feature, target_value: Any
     ) -> tuple[CommandResponse, Device]:
-        """Set a value for a feature and return optimistically updated device.
+        """Set a feature value and return a command-updated device snapshot.
 
         Automatically resolves dependencies (other required parameters for the command)
         by looking them up in the device's feature list.
@@ -292,8 +293,9 @@ class ViClient:
 
         Returns:
             Tuple of (command_response, updated_device).
-            - If successful: device with optimistically updated feature value.
-            - If failed: original device unchanged.
+            - If successful: command-updated device snapshot with the feature
+              value set locally, without an API read-back.
+            - If failed: original device snapshot unchanged.
 
         Raises:
             ValueError: If feature is read-only or value is out of bounds.
@@ -319,9 +321,9 @@ class ViClient:
         # 3. Execution
         response = await self._execute_command(control, payload)
 
-        # 4. Optimistic Device Update
+        # 4. Build a command-updated device snapshot.
         if response.success:
-            # Update feature value optimistically
+            # Preserve all other feature values from the input snapshot.
             updated_feature = replace(feature, value=target_value)
             updated_features = [
                 updated_feature

--- a/src/vi_api_client/cli.py
+++ b/src/vi_api_client/cli.py
@@ -565,12 +565,12 @@ async def _fetch_target_feature(
     """Fetch a target feature together with its complete device context."""
     device = _transient_device(ctx)
     features = await ctx.client.get_features(device)
-    hydrated_device = replace(device, features=features)
-    feature = hydrated_device.get_feature(name)
+    device_snapshot = replace(device, features=features)
+    feature = device_snapshot.get_feature(name)
     if feature is None:
         print(f"Error: Feature '{name}' not found.")
         return None
-    return hydrated_device, feature
+    return device_snapshot, feature
 
 
 def _transient_device(ctx: CLIContext) -> Device:
@@ -639,7 +639,7 @@ def _print_feature_constraints(ctrl: Any) -> None:
     """Helper to print constraints for a feature control.
 
     Args:
-        ctrl: The FeatureControl object containing constraint metadata.
+        ctrl: The FeatureControl command metadata containing constraints.
     """
     constraints = []
     if ctrl.min is not None:

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -108,9 +108,10 @@ DEVICE_TYPE_MAP: dict[str, str] = {
 
 
 class MockViClient(ViClient):
-    """A mock client that returns static responses from JSON files.
+    """Fixture-backed client that runs public workflows without network access.
 
-    Useful for testing, CLI usage without credentials, and development.
+    It uses bundled JSON fixture responses without authentication, which makes
+    it useful for testing, CLI usage, and development.
     """
 
     def __init__(self, device_name: str) -> None:

--- a/src/vi_api_client/models.py
+++ b/src/vi_api_client/models.py
@@ -12,10 +12,10 @@ from .exceptions import ViError
 
 @dataclass(frozen=True)
 class FeatureControl:
-    """Encapsulates write logic for a specific feature.
+    """Command metadata for a writable feature, not an executed command.
 
     Attributes:
-        command_name: Name of the command to execute (e.g. 'setCurve').
+        command_name: Name of the feature command (e.g. 'setCurve').
         param_name: Name of the parameter mapping to this feature (e.g. 'slope').
         required_params: Read-only parameter names required by this command.
             Used for dependency resolution (e.g. ['slope', 'shift']).
@@ -64,7 +64,8 @@ class Feature:
         unit: Optional unit string (e.g. 'celsius').
         is_enabled: Whether the feature is currently enabled on the device.
         is_ready: Whether the feature is ready for interaction.
-        control: Optional control object if the feature is writable.
+        control: Optional `FeatureControl` command metadata if the feature is
+            writable.
     """
 
     name: str
@@ -82,7 +83,7 @@ class Feature:
 
 @dataclass(frozen=True)
 class Device:
-    """Representation of a Viessmann device.
+    """Immutable device snapshot.
 
     Attributes:
         id: Unique device identifier (GUID).
@@ -91,7 +92,7 @@ class Device:
         model_id: Model identifier (e.g. 'Simple_Device').
         device_type: Type classification (e.g. 'heating').
         status: Connection status (e.g. 'Online').
-        features: Read-only associated features.
+        features: Read-only features known when this snapshot was created.
     """
 
     id: str

--- a/src/vi_api_client/parsing.py
+++ b/src/vi_api_client/parsing.py
@@ -208,7 +208,7 @@ def _find_control(
         prop_data: Optional property metadata for constraint fallback.
 
     Returns:
-        FeatureControl object if a matching command is found, else None.
+        FeatureControl command metadata if a matching command is found, else None.
     """
     # 1. Direct Command Search
     # Iterate all commands to see if any parameter matches this property
@@ -230,7 +230,7 @@ def _find_control(
 def _build_control(
     cmd_name: str, cmd_data: dict, target_param: str, parent_name: str, prop_data: Any
 ) -> FeatureControl:
-    """Construct FeatureControl object from command data."""
+    """Construct FeatureControl command metadata from command data."""
     params = cmd_data.get("params", {})
     p_data = params[target_param]
     constraints_dict = p_data.get("constraints", {})


### PR DESCRIPTION
## Summary
- define the canonical consumer-observable language for device snapshots, hydration, feature commands, clients, and credential documents
- align user-facing documentation and Python docstrings with the glossary
- preserve public APIs and existing test names

Closes #69

## Validation
- ruff check .
- ruff format --check .
- pyright
- pytest -q (198 passed)
- python -m build