### PR TITLE
fix(api): enforce current-device feature command invariants

### DIFF
--- a/docs/01_getting_started.md
+++ b/docs/01_getting_started.md
@@ -113,14 +113,12 @@ To change settings (e.g., set heating mode), you use the high-level `set_feature
 async def set_heating_mode(client, device):
     feature_name = "heating.circuits.0.operating.modes.active"
 
-    # 1. Fetch the feature
-    # We use get_features with feature_names list for efficiency
-    features = await client.get_features(device, feature_names=[feature_name])
-    if not features:
+    # 1. Refresh the device snapshot so command dependencies are current.
+    device = await client.update_device(device)
+    feature = device.get_feature(feature_name)
+    if feature is None:
         print("Feature not found")
         return
-
-    feature = features[0]
 
     # 2. Check if writable
     if feature.is_writable:

--- a/docs/02_api_structure.md
+++ b/docs/02_api_structure.md
@@ -78,7 +78,9 @@ If a feature is writable, it has a `.control` attribute with metadata:
 
 *   `command_name`: The internal command to send (e.g., `setCurve`)
 *   `param_name`: The parameter this feature maps to (e.g., `slope`)
-*   `required_params`: Parameter names used to assemble the command payload, including `param_name` (e.g., `['slope', 'shift']`)
+*   `required_params`: API parameters marked required, plus parameters with no
+    `required` marker; explicitly optional parameters are excluded (e.g.,
+    `['slope', 'shift']`)
 *   `parent_feature_name`: Name of the parent feature, used to resolve sibling dependencies (e.g., `heating.circuits.0.heating.curve`)
 *   `uri`: The API URI endpoint for executing the command
 *   `min` / `max` / `step`: Numerical constraints

--- a/docs/04_models_reference.md
+++ b/docs/04_models_reference.md
@@ -97,7 +97,7 @@ This object abstracts away the complexity of Viessmann Commands. You rarely inte
 | :--- | :--- | :--- | :--- |
 | `command_name` | `str` | The internal command name. | `'setCurve'` |
 | `param_name` | `str` | The parameter name this feature maps to. | `'slope'` |
-| `required_params` | `Sequence[str]` | Read-only parameter names used to assemble the command payload. | `('slope', 'shift')` |
+| `required_params` | `Sequence[str]` | Read-only parameters marked required by the API (or with no marker); explicitly optional parameters are excluded. | `('slope', 'shift')` |
 | `parent_feature_name` | `str` | Name of the parent feature (used for sibling lookups). | `'heating.circuits.0.heating.curve'` |
 | `uri` | `str` | The API endpoint for this specific command. | `'.../features/heating.circuits.0...'` |
 | `min` | `float \| None` | Minimum allowed value (numeric). | `0.2` |

--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -116,23 +116,32 @@ for device_id, error in result.errors_by_device_id.items():
 semantics rather than this gateway-scoped partial-result contract.
 
 ### `set_feature(device: Device, feature: Feature, target_value: Any) -> tuple[CommandResponse, Device]`
-Sends a feature command for a writable feature and returns a command-updated
-device snapshot after a successful command response, without an API read-back.
+Sends a feature command for the feature with the same name in the supplied
+current device snapshot and returns a command-updated device snapshot after a
+successful command response, without an API read-back.
 
 *   **Parameters**:
     *   `device`: The `Device` object.
-    *   `feature`: The `Feature` object you want to change (must be writable).
+    *   `feature`: A `Feature` whose name is present in `device`; the current
+        device feature must be writable, enabled, and ready.
     *   `target_value`: The new value you want to set.
 *   **Returns**: Tuple of `(CommandResponse, Device)`:
     *   `CommandResponse`: Object with `success`, `message`, and `reason` fields.
     *   `Device`: Command-updated device snapshot with the feature value set
         locally on success, or the original snapshot on failure.
 *   **Raises**:
-    *   `ValueError` if the feature is read-only or the value violates client-side constraints.
+    *   `ValueError` if the feature is absent from the device, unavailable,
+        missing a required enabled and ready sibling value, or violates
+        client-side constraints.
     *   `ViValidationError` if the API rejects the generated command payload.
     *   `ViConnectionError` if the API call fails.
-*   **Magic**: This method automatically resolves the correct command name and parameter name from the feature's definition.
-*   **Important**: Always use the returned `Device` for subsequent calls to ensure correct dependency resolution for interdependent features.
+*   **Magic**: This method uses the current device feature's command metadata,
+    always includes its target parameter, and resolves each other required
+    parameter from an enabled, ready sibling feature with a non-`None` value.
+    Optional sibling parameters are not added automatically.
+*   **Important**: The returned device is a local command-updated snapshot, not
+    an API refresh. Always use it for subsequent commands, then refresh when
+    authoritative API state is needed.
 
 **Example**:
 ```python
@@ -153,8 +162,11 @@ parameter is sent unchanged.
 Use it only when the caller already has the complete command payload, such as
 an advanced integration writing both heating-curve values at once.
 
-The method raises `ValueError` when the supplied feature is read-only. API and
-connection failures use the corresponding `ViError` subclasses.
+The feature must be writable, enabled, and ready. The supplied payload must
+contain the target parameter and every required parameter; additional
+parameters are allowed and the mapping is sent unchanged. The method raises
+`ValueError` for local contract violations. API and connection failures use the
+corresponding `ViError` subclasses.
 
 ```python
 response = await client.execute_command(slope_feature, {"slope": 0.7, "shift": 7.0})

--- a/src/vi_api_client/api.py
+++ b/src/vi_api_client/api.py
@@ -281,14 +281,14 @@ class ViClient:
     async def set_feature(
         self, device: Device, feature: Feature, target_value: Any
     ) -> tuple[CommandResponse, Device]:
-        """Set a feature value and return a command-updated device snapshot.
+        """Set a current device feature and return a command-updated snapshot.
 
-        Automatically resolves dependencies (other required parameters for the command)
-        by looking them up in the device's feature list.
+        Resolves ``feature.name`` against ``device`` before validating its current
+        command availability, constraints, and required sibling parameters.
 
         Args:
             device: The device allowing context lookup for dependencies.
-            feature: The feature to set.
+            feature: A feature whose name identifies the current device feature.
             target_value: The value to write.
 
         Returns:
@@ -298,16 +298,18 @@ class ViClient:
             - If failed: original device snapshot unchanged.
 
         Raises:
-            ValueError: If feature is read-only or value is out of bounds.
+            ValueError: If the named feature is absent or unavailable, a required
+                sibling is absent, unavailable, or has no value, or the target
+                value violates its constraints.
         """
-        if not feature.is_writable:
-            raise ValueError(f"Feature '{feature.name}' is read-only.")
+        canonical_feature = device.get_feature(feature.name)
+        if canonical_feature is None:
+            raise ValueError(f"Feature '{feature.name}' is not present on the device.")
 
-        control = feature.control
-        assert control is not None
+        control = self._get_writable_command_control(canonical_feature)
         _LOGGER.debug(
             "Setting %s to %s via %s",
-            feature.name,
+            canonical_feature.name,
             target_value,
             control.command_name,
         )
@@ -324,10 +326,10 @@ class ViClient:
         # 4. Build a command-updated device snapshot.
         if response.success:
             # Preserve all other feature values from the input snapshot.
-            updated_feature = replace(feature, value=target_value)
+            updated_feature = replace(canonical_feature, value=target_value)
             updated_features = [
                 updated_feature
-                if existing_feature.name == feature.name
+                if existing_feature.name == canonical_feature.name
                 else existing_feature
                 for existing_feature in device.features
             ]
@@ -340,29 +342,66 @@ class ViClient:
     async def execute_command(
         self, feature: Feature, parameters: dict[str, Any]
     ) -> CommandResponse:
-        """Execute an explicit feature command without changing its parameters.
+        """Execute an explicit available-feature command without changing parameters.
 
         Args:
-            feature: A writable feature that identifies the command endpoint.
+            feature: A writable, enabled, and ready feature identifying the command.
             parameters: Complete command parameters to send exactly as supplied.
 
         Returns:
             The command response from the API.
 
         Raises:
-            ValueError: If the feature is read-only.
+            ValueError: If the feature is unavailable or the payload omits its
+                target or a required parameter.
         """
-        if not feature.is_writable:
-            raise ValueError(f"Feature '{feature.name}' is read-only.")
-
-        control = feature.control
-        assert control is not None
+        control = self._get_writable_command_control(feature)
+        self._validate_explicit_command_payload(control, parameters)
         _LOGGER.debug("Executing %s for %s", control.command_name, feature.name)
         return await self._execute_command(control, parameters)
 
     # ------------------------------------------------------------------
     # Private Helper Methods
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_writable_command_control(feature: Feature) -> FeatureControl:
+        """Validate a feature's command availability and return its control.
+
+        Raises:
+            ValueError: If the feature cannot currently execute a command.
+        """
+        if not feature.is_writable:
+            raise ValueError(f"Feature '{feature.name}' is read-only.")
+        if not feature.is_enabled:
+            raise ValueError(f"Feature '{feature.name}' is disabled.")
+        if not feature.is_ready:
+            raise ValueError(f"Feature '{feature.name}' is not ready.")
+
+        control = feature.control
+        assert control is not None
+        return control
+
+    @staticmethod
+    def _validate_explicit_command_payload(
+        control: FeatureControl, parameters: dict[str, Any]
+    ) -> None:
+        """Validate the caller-supplied explicit command payload.
+
+        Raises:
+            ValueError: If a target or required parameter is absent.
+        """
+        if control.param_name not in parameters:
+            raise ValueError(
+                f"Command '{control.command_name}' is missing target parameter "
+                f"'{control.param_name}'."
+            )
+        for parameter in control.required_params:
+            if parameter not in parameters:
+                raise ValueError(
+                    f"Command '{control.command_name}' is missing required parameter "
+                    f"'{parameter}'."
+                )
 
     @staticmethod
     def _get_discovery_data(
@@ -541,12 +580,11 @@ class ViClient:
         Returns:
             Dictionary of parameters to be sent as JSON payload.
         """
-        payload = {}
+        payload = {ctrl.param_name: target_value}
 
         for param_key in ctrl.required_params:
             # Case A: The value we want to set
             if param_key == ctrl.param_name:
-                payload[param_key] = target_value
                 continue
 
             # Case B: A dependency parameter (e.g. 'shift' when setting 'slope')
@@ -554,20 +592,32 @@ class ViClient:
             sibling_name = f"{ctrl.parent_feature_name}.{param_key}"
             sibling = device.get_feature(sibling_name)
 
-            if sibling:
-                payload[param_key] = sibling.value
-                _LOGGER.debug(
-                    "  -> Resolved dependency '%s' with value %s",
-                    param_key,
-                    sibling.value,
+            if sibling is None:
+                raise ValueError(
+                    f"Required dependency '{sibling_name}' for command "
+                    f"'{ctrl.command_name}' is not present on the device."
                 )
-            else:
-                _LOGGER.warning(
-                    "  -> Dependency '%s' for command '%s' not found in "
-                    "device features. Sending without it.",
-                    param_key,
-                    ctrl.command_name,
+            if not sibling.is_enabled:
+                raise ValueError(
+                    f"Required dependency '{sibling_name}' for command "
+                    f"'{ctrl.command_name}' is disabled."
                 )
+            if not sibling.is_ready:
+                raise ValueError(
+                    f"Required dependency '{sibling_name}' for command "
+                    f"'{ctrl.command_name}' is not ready."
+                )
+            if sibling.value is None:
+                raise ValueError(
+                    f"Required dependency '{sibling_name}' for command "
+                    f"'{ctrl.command_name}' has no value."
+                )
+            payload[param_key] = sibling.value
+            _LOGGER.debug(
+                "  -> Resolved dependency '%s' with value %s",
+                param_key,
+                sibling.value,
+            )
         return payload
 
     def _validate_constraints(self, ctrl: FeatureControl, value: Any) -> None:

--- a/src/vi_api_client/parsing.py
+++ b/src/vi_api_client/parsing.py
@@ -243,7 +243,7 @@ def _build_control(
     return FeatureControl(
         command_name=cmd_name,
         param_name=target_param,
-        required_params=list(params.keys()),
+        required_params=_get_required_params(params),
         parent_feature_name=parent_name,
         uri=cmd_data.get("uri", ""),
         min=_resolve_constraint(["min"], sources),
@@ -255,6 +255,19 @@ def _build_control(
         max_length=_resolve_constraint(["maxLength"], sources),
         pattern=_resolve_constraint(["pattern", "regEx"], sources),
     )
+
+
+def _get_required_params(params: dict[str, Any]) -> list[str]:
+    """Return parameters required by the API command metadata.
+
+    An omitted marker is conservatively required; only an explicit ``false``
+    declares a parameter optional.
+    """
+    return [
+        name
+        for name, metadata in params.items()
+        if metadata.get("required") is not False
+    ]
 
 
 def _match_parameter(
@@ -335,7 +348,7 @@ def _find_control_for_complex_feature(
                 return FeatureControl(
                     command_name=cmd_name,
                     param_name=target_param,
-                    required_params=list(params.keys()),
+                    required_params=_get_required_params(params),
                     parent_feature_name=base_name,
                     uri=cmd_data.get("uri", ""),
                     value_type=params[target_param].get("type"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1231,7 +1231,7 @@ async def test_execute_command_rejects_malformed_success_response(load_fixture_j
             with pytest.raises(
                 ViResponseError, match="Command response must be an object"
             ):
-                await client.execute_command(slope_feature, {"slope": 0.7})
+                await client.execute_command(slope_feature, {"slope": 0.7, "shift": 4})
 
 
 @pytest.mark.asyncio

--- a/tests/test_feature_command_contract.py
+++ b/tests/test_feature_command_contract.py
@@ -1,0 +1,299 @@
+"""Feature command contracts shared by live and fixture-backed clients."""
+
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from vi_api_client.api import ViClient
+from vi_api_client.mock_client import MockViClient
+from vi_api_client.models import Device, Feature, FeatureControl
+
+
+class _RecordingCommandAdapter:
+    """Record command adapter calls and return a configurable response."""
+
+    def __init__(self, success: bool = True) -> None:
+        """Initialize a successful or rejected command response."""
+        self.calls: list[tuple[FeatureControl, dict[str, Any]]] = []
+        self.success = success
+
+    async def execute_command(
+        self, control: FeatureControl, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Record the command and return its configured response."""
+        self.calls.append((control, parameters))
+        return {"data": {"success": self.success}}
+
+
+def _create_live_client(adapter: _RecordingCommandAdapter) -> ViClient:
+    """Create a live client with a recording command adapter."""
+    client = ViClient.__new__(ViClient)
+    client._command_adapter = adapter
+    return client
+
+
+def _create_fixture_client(adapter: _RecordingCommandAdapter) -> MockViClient:
+    """Create a fixture-backed client with a recording command adapter."""
+    client = MockViClient.__new__(MockViClient)
+    client._command_adapter = adapter
+    return client
+
+
+def _feature(
+    name: str,
+    value: Any,
+    control: FeatureControl | None = None,
+    *,
+    is_enabled: bool = True,
+    is_ready: bool = True,
+) -> Feature:
+    """Build a feature for feature-command contract tests."""
+    return Feature(name, value, None, is_enabled, is_ready, control)
+
+
+def _device(features: list[Feature]) -> Device:
+    """Build a device snapshot containing the provided features."""
+    return Device(
+        id="device-1",
+        gateway_serial="gateway-1",
+        installation_id="installation-1",
+        model_id="model-1",
+        device_type="heating",
+        status="connected",
+        features=features,
+    )
+
+
+def _control(
+    *, required_params: list[str] | None = None, param_name: str = "target"
+) -> FeatureControl:
+    """Build command metadata for a target under ``heating.mode``."""
+    return FeatureControl(
+        command_name="setMode",
+        param_name=param_name,
+        required_params=[param_name] if required_params is None else required_params,
+        parent_feature_name="heating.mode",
+        uri="/commands/setMode",
+    )
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_set_feature_uses_current_canonical_feature_and_updates_snapshot(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+):
+    """The current device feature controls validation, payload, and local update."""
+    # Arrange: The supplied stale feature is read-only, while the snapshot is writable.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+    canonical_control = _control(
+        required_params=["target", "enabled", "count", "label"]
+    )
+    canonical = _feature("heating.mode.target", "old", canonical_control)
+    device = _device(
+        [
+            canonical,
+            _feature("heating.mode.enabled", False),
+            _feature("heating.mode.count", 0),
+            _feature("heating.mode.label", ""),
+        ]
+    )
+    stale = _feature("heating.mode.target", "stale")
+
+    # Act: Set through the stale object using its canonical name.
+    response, updated_device = await client.set_feature(device, stale, "new")
+
+    # Assert: Current metadata and falsey required sibling values are used.
+    assert response.success
+    assert adapter.calls == [
+        (
+            canonical_control,
+            {"target": "new", "enabled": False, "count": 0, "label": ""},
+        )
+    ]
+    assert device.get_feature("heating.mode.target") == canonical
+    assert updated_device is not device
+    updated = updated_device.get_feature("heating.mode.target")
+    assert updated == replace(canonical, value="new")
+
+
+@pytest.mark.parametrize(
+    ("feature", "device_features", "error"),
+    [
+        (_feature("absent", "value", _control()), [], "not present"),
+        (
+            _feature("heating.mode.target", "old"),
+            [_feature("heating.mode.target", "old", _control(), is_enabled=False)],
+            "disabled",
+        ),
+        (
+            _feature("heating.mode.target", "old"),
+            [_feature("heating.mode.target", "old", _control(), is_ready=False)],
+            "not ready",
+        ),
+        (
+            _feature("heating.mode.target", "old"),
+            [
+                _feature(
+                    "heating.mode.target",
+                    "old",
+                    _control(required_params=["target", "other"]),
+                )
+            ],
+            "Required dependency",
+        ),
+    ],
+)
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_set_feature_rejects_invalid_local_contract_without_adapter_io(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+    feature: Feature,
+    device_features: list[Feature],
+    error: str,
+):
+    """Local membership, availability, and dependency failures precede adapter I/O."""
+    # Arrange: Each scenario supplies an invalid current-device command contract.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+    device = _device(device_features)
+
+    # Act and assert: Invalid local state never reaches the adapter.
+    with pytest.raises(ValueError, match=error):
+        await client.set_feature(device, feature, "new")
+    assert adapter.calls == []
+
+
+@pytest.mark.parametrize(
+    ("sibling", "error"),
+    [
+        (_feature("heating.mode.other", "value", is_enabled=False), "disabled"),
+        (_feature("heating.mode.other", "value", is_ready=False), "not ready"),
+        (_feature("heating.mode.other", None), "has no value"),
+    ],
+)
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_set_feature_rejects_unavailable_required_dependencies_before_constraints(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+    sibling: Feature,
+    error: str,
+):
+    """Required dependency validation precedes target constraint validation and I/O."""
+    # Arrange: Both the sibling and target constraint are invalid.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+    control = replace(_control(required_params=["target", "other"]), max=10)
+    target = _feature("heating.mode.target", "old", control)
+    device = _device([target, sibling])
+
+    # Act and assert: The dependency error takes precedence over the target constraint.
+    with pytest.raises(ValueError, match=error):
+        await client.set_feature(device, target, 11)
+    assert adapter.calls == []
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_set_feature_uses_canonical_constraints_before_adapter_io(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+):
+    """Target constraints come from the current device feature before adapter I/O."""
+    # Arrange: The caller supplies stale permissive metadata for a constrained target.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+    canonical = _feature("heating.mode.target", 5, replace(_control(), max=10))
+    stale = _feature("heating.mode.target", 5, _control())
+    device = _device([canonical])
+
+    # Act and assert: The canonical maximum rejects before either adapter can run.
+    with pytest.raises(ValueError, match="max"):
+        await client.set_feature(device, stale, 11)
+    assert adapter.calls == []
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_set_feature_omits_optional_siblings_and_preserves_rejected_device(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+):
+    """Only required dependencies are sent and API rejection retains the snapshot."""
+    # Arrange: The optional sibling is available but must not be sent automatically.
+    adapter = _RecordingCommandAdapter(success=False)
+    client = create_client(adapter)
+    control = _control(required_params=[])
+    canonical = _feature("heating.mode.target", "old", control)
+    device = _device([canonical, _feature("heating.mode.optional", "present")])
+
+    # Act: The command adapter rejects the generated command.
+    response, returned_device = await client.set_feature(device, canonical, "new")
+
+    # Assert: Optional state is absent and the exact original snapshot returns.
+    assert not response.success
+    assert adapter.calls == [(control, {"target": "new"})]
+    assert returned_device is device
+
+
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_execute_command_requires_complete_available_command_without_mutation(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+):
+    """Explicit commands require complete payloads but preserve additional parameters."""
+    # Arrange: The complete payload includes an allowed extra parameter.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+    control = _control(required_params=["target", "dependency"])
+    feature = _feature("heating.mode.target", "old", control)
+    parameters = {"target": "new", "dependency": None, "extra": "kept"}
+
+    # Act: Submit the explicit payload without high-level augmentation.
+    response = await client.execute_command(feature, parameters)
+
+    # Assert: The adapter receives the original mapping unchanged.
+    assert response.success
+    assert adapter.calls == [(control, parameters)]
+    assert parameters == {"target": "new", "dependency": None, "extra": "kept"}
+
+
+@pytest.mark.parametrize(
+    ("feature", "parameters", "error"),
+    [
+        (_feature("target", "old"), {"target": "new"}, "read-only"),
+        (
+            _feature("target", "old", _control(), is_enabled=False),
+            {"target": "new"},
+            "disabled",
+        ),
+        (
+            _feature("target", "old", _control(), is_ready=False),
+            {"target": "new"},
+            "not ready",
+        ),
+        (_feature("target", "old", _control()), {}, "target parameter"),
+        (
+            _feature("target", "old", _control(required_params=["target", "other"])),
+            {"target": "new"},
+            "required parameter",
+        ),
+    ],
+)
+@pytest.mark.parametrize("create_client", [_create_live_client, _create_fixture_client])
+@pytest.mark.asyncio
+async def test_execute_command_rejects_invalid_local_contract_without_adapter_io(
+    create_client: Callable[[_RecordingCommandAdapter], ViClient],
+    feature: Feature,
+    parameters: dict[str, Any],
+    error: str,
+):
+    """Explicit-command preconditions reject before adapter I/O."""
+    # Arrange: Each feature or payload violates the low-level command contract.
+    adapter = _RecordingCommandAdapter()
+    client = create_client(adapter)
+
+    # Act and assert: Local invalidity leaves the adapter untouched.
+    with pytest.raises(ValueError, match=error):
+        await client.execute_command(feature, parameters)
+    assert adapter.calls == []

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -19,6 +19,33 @@ def test_feature_simple_value(load_fixture_json):
     assert feature.unit == "celsius"
 
 
+def test_feature_control_parses_required_parameter_markers():
+    """Command controls include true and unspecified parameters but exclude false."""
+    # Arrange: The command has explicit required, explicit optional, and unspecified params.
+    raw_feature = {
+        "feature": "heating.mode",
+        "properties": {"target": {"value": "old"}},
+        "commands": {
+            "setMode": {
+                "uri": "/commands/setMode",
+                "params": {
+                    "target": {"required": False},
+                    "requiredSibling": {"required": True},
+                    "unspecifiedSibling": {},
+                    "optionalSibling": {"required": False},
+                },
+            }
+        },
+    }
+
+    # Act: Parse the API-shaped feature response.
+    feature = parse_feature_flat(raw_feature)[0]
+
+    # Assert: Explicit false is optional while missing markers remain conservative.
+    assert feature.control is not None
+    assert feature.control.required_params == ("requiredSibling", "unspecifiedSibling")
+
+
 def test_feature_status(load_fixture_json):
     # Arrange: Load fixture for circulation pump status feature.
     data = load_fixture_json("parsing/status_feature.json")


### PR DESCRIPTION
## Summary
- resolve set_feature through the current device snapshot and enforce command availability/dependencies before adapter I/O
- parse required command parameters accurately and validate explicit command payloads
- document the current command contract and add shared live/fixture client coverage

Closes #70

## Validation
- ruff check .
- ruff format --check .
- pyright --pythonpath .venv/bin/python
- python -m pytest -q (231 passed)
- python -m build