### PR TITLE
feat: define auth refresh concurrency ownership

### DIFF
--- a/docs/03_auth_reference.md
+++ b/docs/03_auth_reference.md
@@ -40,6 +40,20 @@ async def main():
 
 Alternatively, call `await auth.async_close()` when the provider is no longer
 needed. `async_close()` never closes a session passed through `websession`.
+When it owns a session, it lets an already-running token refresh finish before
+closing that session.
+
+## Refresh Concurrency
+
+One standalone `OAuth` instance coordinates token refreshes for tasks on one
+event loop. Overlapping automatic access-token refreshes and explicit
+`async_refresh_access_token()` calls share one in-flight refresh; cancelling a
+caller does not cancel that refresh for the other waiters. A refresh failure is
+returned to the waiting callers, and a later call can try again.
+
+Share one `OAuth` instance within a running application context. The library
+does not synchronize token refreshes across threads, event loops, instances,
+processes, or token files.
 
 ## Base Class: `AbstractAuth`
 

--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -25,6 +25,13 @@ already known.
 An application that supplies `OAuth(websession=session)` owns and closes that
 session. An `AbstractAuth` provider closes only a session it created itself.
 
+Applications own request concurrency, retry, backoff, polling, and stale-state
+policy. `ViClient` does not automatically retry authentication, rate-limit,
+server, or connection failures, and does not provide a client-wide rate limiter
+or concurrency control. A gateway-scoped device refresh keeps its existing
+partial-result behavior; consumers decide how to use stale state and partial
+availability.
+
 `ViClient` is the live client when configured with authentication: its public
 workflows read from the Viessmann API. `MockViClient(device_name)` is the
 fixture-backed client: it runs those public workflows against bundled fixture

--- a/docs/07_exceptions_reference.md
+++ b/docs/07_exceptions_reference.md
@@ -25,7 +25,7 @@ from vi_api_client import (
     *   `ViConnectionError`: Network issues (DNS, Timeout, Connection Refused).
     *   `ViAuthError`: Authentication failed (401/403). check your tokens.
     *   `ViNotFoundError`: Resource not found (404). Typically happens if you request a feature that does not exist on the device.
-    *   `ViRateLimitError`: API Rate Limit exceeded (429). You should back off.
+    *   `ViRateLimitError`: API Rate Limit exceeded (429), optionally with server retry guidance.
     *   `ViResponseError`: A successful HTTP response violates the expected response contract.
     *   `ViValidationError`: Bad Request (400) or Validation Error (422). Includes detailed validation messages from the API.
     *   `ViServerInternalError`: Server issues (500+).
@@ -76,16 +76,21 @@ except ViNotFoundError:
 ```
 
 ### Rate Limits
-If you hit a rate limit (429), `ViRateLimitError` is raised. The API might imply a cooldown period.
+If you hit a rate limit (429), `ViRateLimitError` is raised. Its optional
+`retry_after` attribute is a non-negative delay in seconds parsed from a valid
+`Retry-After` response header; it is `None` when the server does not provide
+usable guidance. The library never sleeps or retries automatically, so the
+calling application owns the backoff decision.
 
 ```python
 from asyncio import sleep
 
 try:
     data = await client.get_features(...)
-except ViRateLimitError:
-    print("Rate limit hit! Waiting 60s...")
-    await sleep(60)
+except ViRateLimitError as error:
+    delay = error.retry_after if error.retry_after is not None else 60
+    print(f"Rate limit hit! Waiting {delay}s...")
+    await sleep(delay)
 ```
 
 ## Next Steps

--- a/docs/adr/0002-keep-request-policy-with-consumers.md
+++ b/docs/adr/0002-keep-request-policy-with-consumers.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+---
+
+# Keep request policy with consumers
+
+Consumers own API request concurrency, retries, backoff, polling cadence, stale
+state, and the interpretation of partial availability. The library does not add
+a client-wide lock, rate limiter, retry policy, or automatic parallelization of
+composite reads.
+
+Each standalone `OAuth` instance coordinates its own in-flight token refreshes
+for tasks on one event loop. Overlapping automatic and explicit refresh callers
+share that operation, and cancellation of one caller does not cancel it for the
+others. Applications should share one `OAuth` instance for a running context;
+the library does not coordinate refreshes across threads, event loops,
+instances, processes, or credential documents.
+
+On a 429 response, `ViRateLimitError.retry_after` exposes valid server guidance
+in seconds when available. Consumers decide whether and how to delay and retry.

--- a/src/vi_api_client/_adapter.py
+++ b/src/vi_api_client/_adapter.py
@@ -1,6 +1,9 @@
 """Private API adapters for live and fixture-backed client workflows."""
 
 import logging
+import math
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
 import aiohttp
@@ -170,7 +173,12 @@ async def _raise_for_status(response: aiohttp.ClientResponse) -> None:
     if status == 404:
         raise ViNotFoundError(f"Not Found: {error_message}", vi_error_id, error_type)
     if status == 429:
-        raise ViRateLimitError("Rate Limit Exceeded", vi_error_id, error_type)
+        raise ViRateLimitError(
+            "Rate Limit Exceeded",
+            vi_error_id,
+            error_type,
+            retry_after=_parse_retry_after(response.headers.get("Retry-After")),
+        )
     if status in (400, 422):
         raise ViValidationError(
             error_message, vi_error_id, validation_details, error_type
@@ -180,3 +188,26 @@ async def _raise_for_status(response: aiohttp.ClientResponse) -> None:
             f"Server Error {status}: {error_message}", vi_error_id, error_type
         )
     raise ViError(f"Unknown Error {status}: {error_message}", vi_error_id, error_type)
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Return a non-negative retry duration from an HTTP Retry-After value."""
+    if value is None:
+        return None
+
+    try:
+        numeric_delay = float(value)
+    except ValueError:
+        numeric_delay = None
+    if numeric_delay is not None:
+        if not math.isfinite(numeric_delay) or numeric_delay < 0:
+            return None
+        return numeric_delay
+
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except IndexError, TypeError, ValueError:
+        return None
+    if retry_at.tzinfo is None:
+        return None
+    return max(0.0, (retry_at - datetime.now(UTC)).total_seconds())

--- a/src/vi_api_client/auth.py
+++ b/src/vi_api_client/auth.py
@@ -1,5 +1,6 @@
 """Authentication module for Viessmann API."""
 
+import asyncio
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -115,6 +116,7 @@ class OAuth(AbstractAuth):
         self.scope = scope
         self._token_info: dict[str, Any] = {}
         self._pkce_verifier: str | None = None
+        self._refresh_task: asyncio.Task[None] | None = None
 
         # Load existing tokens if available.
         self._load_tokens()
@@ -175,8 +177,8 @@ class OAuth(AbstractAuth):
 
             self._update_tokens(await resp.json())
 
-    async def async_refresh_access_token(self) -> None:
-        """Refresh the access token."""
+    async def _async_refresh_access_token(self) -> None:
+        """Refresh the access token through the token endpoint."""
         refresh_token = self._token_info.get("refresh_token")
         if not refresh_token:
             raise ViAuthError("No refresh token available.")
@@ -195,6 +197,43 @@ class OAuth(AbstractAuth):
                 raise ViAuthError(f"Failed to refresh token: {text}")
 
             self._update_tokens(await resp.json())
+
+    async def async_refresh_access_token(self) -> None:
+        """Refresh the access token, sharing an in-flight refresh per instance.
+
+        Raises:
+            ViAuthError: If the refresh token is unavailable or rejected.
+        """
+        refresh_task = self._refresh_task
+        if refresh_task is None or refresh_task.done():
+            refresh_task = asyncio.create_task(self._async_refresh_access_token())
+            self._refresh_task = refresh_task
+
+        try:
+            await asyncio.shield(refresh_task)
+        finally:
+            if refresh_task.done() and self._refresh_task is refresh_task:
+                self._refresh_task = None
+
+    async def async_close(self) -> None:
+        """Let an in-flight refresh settle before closing an owned session."""
+        refresh_task = self._refresh_task
+        if refresh_task is not None:
+            try:
+                await asyncio.shield(refresh_task)
+            except (
+                ViAuthError,
+                aiohttp.ClientError,
+                OSError,
+                TimeoutError,
+                ValueError,
+            ):
+                _LOGGER.exception("Token refresh failed while closing authentication")
+            finally:
+                if refresh_task.done() and self._refresh_task is refresh_task:
+                    self._refresh_task = None
+
+        await super().async_close()
 
     async def async_get_access_token(self) -> str:
         """Return valid access token, refreshing if necessary."""

--- a/src/vi_api_client/exceptions.py
+++ b/src/vi_api_client/exceptions.py
@@ -43,9 +43,26 @@ class ViNotFoundError(ViError):
 
 
 class ViRateLimitError(ViError):
-    """429 Rate Limit Exceeded."""
+    """429 Rate Limit Exceeded with optional server retry guidance."""
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        error_id: str | None = None,
+        error_type: str | None = None,
+        *,
+        retry_after: float | None = None,
+    ) -> None:
+        """Initialize a rate-limit error.
+
+        Args:
+            message: The error message.
+            error_id: Optional unique error identifier from the API.
+            error_type: Optional Viessmann API error classification.
+            retry_after: Optional server-recommended delay in seconds.
+        """
+        super().__init__(message, error_id, error_type)
+        self.retry_after = retry_after
 
 
 class ViResponseError(ViError):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 """Tests for vitoclient.auth module."""
 
+import asyncio
 import json
 import os
 import stat
 import time
 from pathlib import Path
+from typing import Self
 from unittest.mock import MagicMock
 
 import aiohttp
@@ -15,6 +17,76 @@ from vi_api_client.api import ViClient
 from vi_api_client.auth import AbstractAuth, OAuth
 from vi_api_client.const import API_BASE_URL, ENDPOINT_INSTALLATIONS, ENDPOINT_TOKEN
 from vi_api_client.exceptions import ViAuthError
+
+
+class _BlockingRefreshResponse:
+    """Delay a token response until a test releases it."""
+
+    def __init__(
+        self,
+        started: asyncio.Event,
+        release: asyncio.Event,
+        status: int,
+        error: Exception | None,
+    ) -> None:
+        """Initialize the controllable response."""
+        self.status = status
+        self._started = started
+        self._release = release
+        self._error = error
+
+    async def __aenter__(self) -> Self:
+        """Wait until the test releases the token response."""
+        self._started.set()
+        await self._release.wait()
+        if self._error is not None:
+            raise self._error
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Leave the token response context."""
+
+    async def json(self) -> dict[str, object]:
+        """Return a successful refreshed token payload."""
+        return {
+            "access_token": "refreshed_access_token",
+            "refresh_token": "refreshed_refresh_token",
+            "expires_in": 3600,
+        }
+
+    async def text(self) -> str:
+        """Return a token endpoint failure body."""
+        return "refresh rejected"
+
+
+class _BlockingRefreshSession:
+    """Provide one controllable refresh request boundary."""
+
+    def __init__(self, status: int = 200, error: Exception | None = None) -> None:
+        """Initialize refresh request tracking."""
+        self.calls = 0
+        self.status = status
+        self.error = error
+        self.closed = False
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def post(self, *args: object, **kwargs: object) -> _BlockingRefreshResponse:
+        """Record and return a delayed token response."""
+        self.calls += 1
+        return _BlockingRefreshResponse(
+            self.started, self.release, self.status, self.error
+        )
+
+    async def close(self) -> None:
+        """Record that an owned session was closed."""
+        self.closed = True
+
+
+async def _release_refresh_when_started(session: _BlockingRefreshSession) -> None:
+    """Release a delayed refresh after its HTTP request has started."""
+    await session.started.wait()
+    session.release.set()
 
 
 def test_abstract_auth_cannot_be_instantiated():
@@ -322,6 +394,253 @@ async def test_async_refresh_access_token(oauth_with_tokens, load_fixture_json):
             ]
             == "refreshed_access_token"
         )
+
+
+@pytest.mark.asyncio
+async def test_overlapping_access_token_refreshes_share_one_request(
+    oauth_with_tokens,
+) -> None:
+    """Overlapping automatic refreshes should share one token request."""
+    # Arrange: Expire the token and pause the first refresh at the HTTP boundary.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+
+    # Act: Request a token concurrently from both callers.
+    first_token, second_token, _ = await asyncio.gather(
+        oauth_with_tokens.async_get_access_token(),
+        oauth_with_tokens.async_get_access_token(),
+        _release_refresh_when_started(session),
+    )
+
+    # Assert: Both callers receive the refresh result from one HTTP request.
+    assert (first_token, second_token) == (
+        "refreshed_access_token",
+        "refreshed_access_token",
+    )
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_overlapping_explicit_and_automatic_refreshes_share_one_request(
+    oauth_with_tokens,
+) -> None:
+    """Explicit and automatic refresh callers should share one refresh."""
+    # Arrange: Expire the token and delay the shared refresh.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+
+    # Act: Start an explicit refresh alongside automatic token retrieval.
+    _, token, _ = await asyncio.gather(
+        oauth_with_tokens.async_refresh_access_token(),
+        oauth_with_tokens.async_get_access_token(),
+        _release_refresh_when_started(session),
+    )
+
+    # Assert: Both calls use the same successful refresh.
+    assert token == "refreshed_access_token"
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_overlapping_explicit_refreshes_share_one_request(
+    oauth_with_tokens,
+) -> None:
+    """Overlapping explicit refreshes should share one token request."""
+    # Arrange: Delay the first explicit refresh at the HTTP boundary.
+    session = _BlockingRefreshSession()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+
+    # Act: Start two explicit refreshes at the same time.
+    _, _, _ = await asyncio.gather(
+        oauth_with_tokens.async_refresh_access_token(),
+        oauth_with_tokens.async_refresh_access_token(),
+        _release_refresh_when_started(session),
+    )
+
+    # Assert: Both calls use the same token request.
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_later_explicit_refresh_starts_a_new_request(oauth_with_tokens) -> None:
+    """A completed explicit refresh should not suppress a later forced refresh."""
+    # Arrange: Allow token responses to complete immediately.
+    session = _BlockingRefreshSession()
+    session.release.set()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+
+    # Act: Refresh twice without overlap.
+    await oauth_with_tokens.async_refresh_access_token()
+    await oauth_with_tokens.async_refresh_access_token()
+
+    # Assert: Each completed explicit refresh sends a new request.
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelling_one_refresh_waiter_keeps_the_shared_refresh_running(
+    oauth_with_tokens,
+) -> None:
+    """Cancelling one caller should not cancel a shared refresh."""
+    # Arrange: Start a delayed automatic refresh.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+    cancelled_caller = asyncio.create_task(oauth_with_tokens.async_get_access_token())
+    await session.started.wait()
+
+    async def cancel_and_release() -> None:
+        """Cancel one waiter after the remaining waiter joins the refresh."""
+        cancelled_caller.cancel()
+        session.release.set()
+
+    # Act: Join the refresh from a second caller while cancelling the first.
+    remaining_token, _ = await asyncio.gather(
+        oauth_with_tokens.async_get_access_token(), cancel_and_release()
+    )
+
+    # Assert: The remaining caller receives the result from the one request.
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_caller
+    assert remaining_token == "refreshed_access_token"
+    assert session.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_shared_refresh_is_visible_to_waiters_and_can_retry(
+    oauth_with_tokens,
+) -> None:
+    """Shared failures should propagate once and permit a later retry."""
+    # Arrange: Make the shared refresh fail after both callers have started.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession(status=400)
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+
+    first_caller, second_caller, _ = await asyncio.gather(
+        asyncio.create_task(oauth_with_tokens.async_get_access_token()),
+        asyncio.create_task(oauth_with_tokens.async_get_access_token()),
+        asyncio.create_task(_release_refresh_when_started(session)),
+        return_exceptions=True,
+    )
+
+    # Assert: Both waiters observe the refresh failure.
+    assert isinstance(first_caller, ViAuthError)
+    assert isinstance(second_caller, ViAuthError)
+    assert session.calls == 1
+
+    # Act: Allow a later caller to refresh successfully.
+    session.status = 200
+    token = await oauth_with_tokens.async_get_access_token()
+
+    # Assert: The failed operation was not retained indefinitely.
+    assert token == "refreshed_access_token"
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_refresh_then_closes_an_owned_session(
+    oauth_with_tokens, monkeypatch
+) -> None:
+    """Closing should settle a refresh before closing its owned session."""
+    # Arrange: Make OAuth lazily create a delayed, owned transport session.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession()
+    monkeypatch.setattr("vi_api_client.auth.aiohttp.ClientSession", lambda: session)
+    refresh = asyncio.create_task(oauth_with_tokens.async_get_access_token())
+    await session.started.wait()
+
+    # Act: Begin closing while the refresh remains in flight, then release it.
+    close = asyncio.create_task(oauth_with_tokens.async_close())
+    session.release.set()
+    token, _ = await asyncio.gather(refresh, close)
+
+    # Assert: The refresh completes and the internally owned session closes.
+    assert token == "refreshed_access_token"
+    assert session.closed is True
+    assert oauth_with_tokens.websession is None
+
+
+@pytest.mark.asyncio
+async def test_close_keeps_an_external_session_open_while_refreshing(
+    oauth_with_tokens,
+) -> None:
+    """Closing should not close a caller-provided session around a refresh."""
+    # Arrange: Start a delayed refresh through an externally managed session.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession()
+    oauth_with_tokens.websession = session  # type: ignore[assignment]
+    refresh = asyncio.create_task(oauth_with_tokens.async_get_access_token())
+    await session.started.wait()
+
+    # Act: Close the provider while the refresh is in flight.
+    close = asyncio.create_task(oauth_with_tokens.async_close())
+    session.release.set()
+    await asyncio.gather(refresh, close)
+
+    # Assert: Caller-owned sessions remain available.
+    assert session.closed is False
+
+
+@pytest.mark.asyncio
+async def test_close_logs_and_cleans_up_a_cancelled_callers_refresh_failure(
+    oauth_with_tokens, monkeypatch, caplog
+) -> None:
+    """Closing should handle a refresh failure left by a cancelled caller."""
+    # Arrange: Start a failed refresh with an owned delayed transport session.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession(status=400)
+    monkeypatch.setattr("vi_api_client.auth.aiohttp.ClientSession", lambda: session)
+    cancelled_caller = asyncio.create_task(oauth_with_tokens.async_get_access_token())
+    await session.started.wait()
+    cancelled_caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_caller
+
+    # Act: Let close observe the failed shared refresh.
+    session.release.set()
+    await oauth_with_tokens.async_close()
+    await oauth_with_tokens.async_close()
+
+    # Assert: Closing does not retry, logs once, and closes the owned session.
+    assert session.calls == 1
+    assert session.closed is True
+    assert (
+        sum(
+            "Token refresh failed while closing authentication" in record.message
+            for record in caplog.records
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_cleans_up_a_cancelled_callers_transport_failure(
+    oauth_with_tokens, monkeypatch, caplog
+) -> None:
+    """Closing should still close an owned session after a transport failure."""
+    # Arrange: Start a refresh that fails while opening the token response.
+    oauth_with_tokens._token_info["expires_at"] = 0
+    session = _BlockingRefreshSession(error=aiohttp.ClientConnectionError())
+    monkeypatch.setattr("vi_api_client.auth.aiohttp.ClientSession", lambda: session)
+    cancelled_caller = asyncio.create_task(oauth_with_tokens.async_get_access_token())
+    await session.started.wait()
+    cancelled_caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_caller
+
+    # Act: Let close observe and clean up the transport failure.
+    session.release.set()
+    await oauth_with_tokens.async_close()
+
+    # Assert: Closing logs the failure and releases the owned transport session.
+    assert session.calls == 1
+    assert session.closed is True
+    assert any(
+        "Token refresh failed while closing authentication" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,7 @@
 """Tests for private live adapter HTTP and authentication behavior."""
 
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -7,6 +9,7 @@ import pytest
 from aioresponses import aioresponses
 
 from vi_api_client._adapter import _LiveAdapter
+from vi_api_client.api import ViClient
 from vi_api_client.auth import AbstractAuth
 from vi_api_client.const import API_BASE_URL, ENDPOINT_INSTALLATIONS
 from vi_api_client.exceptions import (
@@ -126,3 +129,70 @@ def test_validation_error_keeps_existing_positional_arguments() -> None:
     assert error.error_id == "error-123"
     assert error.error_type is None
     assert error.validation_errors == validation_errors
+
+
+def test_rate_limit_error_keeps_existing_positional_arguments() -> None:
+    """Rate-limit errors should retain their existing positional signature."""
+    # Arrange and Act: Construct with positional arguments supported before retry data.
+    error = ViRateLimitError("Rate limited", "error-123", "RATE_LIMIT")
+
+    # Assert: Existing values retain their meanings and retry data defaults to none.
+    assert error.error_id == "error-123"
+    assert error.error_type == "RATE_LIMIT"
+    assert error.retry_after is None
+
+
+@pytest.mark.parametrize(
+    ("retry_after_header", "expected_retry_after"),
+    [
+        ("12.5", 12.5),
+        ("-5", None),
+        ("not-a-duration", None),
+        (None, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_client_normalizes_numeric_or_invalid_retry_after_without_retrying(
+    retry_after_header: str | None, expected_retry_after: float | None
+) -> None:
+    """A 429 should expose numeric guidance through one client request."""
+    # Arrange: Configure a rate-limited public client request.
+    url = f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}"
+    headers = (
+        {"Retry-After": retry_after_header} if retry_after_header is not None else {}
+    )
+    async with aiohttp.ClientSession() as session:
+        client = ViClient(_StaticAuth(session))
+        with aioresponses() as mock_responses:
+            mock_responses.get(url, status=429, headers=headers)
+
+            # Act and assert: The request raises once with parsed retry guidance.
+            with pytest.raises(ViRateLimitError) as raised_error:
+                await client.get_installations()
+
+    # Assert: The error guidance and request count match the response.
+    assert raised_error.value.retry_after == expected_retry_after
+    assert len(mock_responses.requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_client_normalizes_http_date_retry_after_without_retrying() -> None:
+    """A 429 HTTP-date header should become a non-negative delay in seconds."""
+    # Arrange: Configure a public client request with a future HTTP-date header.
+    url = f"{API_BASE_URL}{ENDPOINT_INSTALLATIONS}"
+    retry_at = datetime.now(UTC) + timedelta(seconds=30)
+    async with aiohttp.ClientSession() as session:
+        client = ViClient(_StaticAuth(session))
+        with aioresponses() as mock_responses:
+            mock_responses.get(
+                url, status=429, headers={"Retry-After": format_datetime(retry_at)}
+            )
+
+            # Act and assert: The client exposes the server delay without retrying.
+            with pytest.raises(ViRateLimitError) as raised_error:
+                await client.get_installations()
+
+    # Assert: The date becomes an approximate non-negative duration from one request.
+    assert raised_error.value.retry_after is not None
+    assert 0 <= raised_error.value.retry_after <= 30
+    assert len(mock_responses.requests) == 1


### PR DESCRIPTION
Closes #71\n\n## Summary\n- coalesce per-instance OAuth token refreshes and preserve shared refreshes through caller cancellation\n- expose parsed Retry-After guidance on ViRateLimitError without automatic retry behavior\n- document the consumer-owned request policy and record it in an ADR\n\n## Validation\n- ruff check .\n- ruff format --check .\n- pyright --pythonpath .venv/bin/python\n- python -m pytest -q (247 passed)\n- python -m build