### PR TITLE
Make bundled fixture metadata self-contained

### DIFF
--- a/docs/05_client_reference.md
+++ b/docs/05_client_reference.md
@@ -35,7 +35,9 @@ availability.
 `ViClient` is the live client when configured with authentication: its public
 workflows read from the Viessmann API. `MockViClient(device_name)` is the
 fixture-backed client: it runs those public workflows against bundled fixture
-responses without authentication or network requests.
+responses without authentication or network requests. Its bundled fixture
+catalog defines each selectable fixture name, model identity, and device type;
+`MockViClient.get_available_mock_devices()` lists those selectable names.
 
 ## Discovery Methods
 

--- a/src/vi_api_client/fixtures/discovery.json
+++ b/src/vi_api_client/fixtures/discovery.json
@@ -20,5 +20,42 @@
         "installationId": "99999"
       }
     ]
-  }
+  },
+  "devices": [
+    {
+      "fixtureName": "Vitocal200S",
+      "modelId": "Vitocal200S",
+      "deviceType": "heating"
+    },
+    {
+      "fixtureName": "Vitocal222S",
+      "modelId": "Vitocal222S",
+      "deviceType": "heating"
+    },
+    {
+      "fixtureName": "Vitocal250A",
+      "modelId": "Vitocal250A",
+      "deviceType": "heating"
+    },
+    {
+      "fixtureName": "Vitocal333G-with-Vitovent300F",
+      "modelId": "Vitocal333G-with-Vitovent300F",
+      "deviceType": "heating"
+    },
+    {
+      "fixtureName": "Vitocharge03",
+      "modelId": "Vitocharge03",
+      "deviceType": "battery"
+    },
+    {
+      "fixtureName": "Vitodens200W",
+      "modelId": "Vitodens200W",
+      "deviceType": "heating"
+    },
+    {
+      "fixtureName": "Vitopure350",
+      "modelId": "Vitopure350",
+      "deviceType": "ventilation"
+    }
+  ]
 }

--- a/src/vi_api_client/mock_client.py
+++ b/src/vi_api_client/mock_client.py
@@ -1,6 +1,9 @@
+"""Fixture-backed client adapters and deterministic command simulation."""
+
 import json
+import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 from ._adapter import _CommandAdapter, _DiscoveryAdapter
 from .api import ViClient
@@ -9,6 +12,31 @@ from .models import (
     FeatureControl,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
+
+class _FixtureMetadata(TypedDict):
+    """The discovery identity of one bundled feature fixture."""
+
+    fixtureName: str
+    modelId: str
+    deviceType: str
+
+
+class _FixtureDiscoveryData(TypedDict):
+    """The bundled fixture discovery envelopes and metadata catalog."""
+
+    installations: dict[str, list[dict[str, Any]]]
+    gateways: dict[str, list[dict[str, Any]]]
+    devices: list[_FixtureMetadata]
+
+
+def _load_fixture_discovery_data() -> _FixtureDiscoveryData:
+    """Load the bundled fixture discovery envelopes and metadata catalog."""
+    fixture_path = Path(__file__).parent / "fixtures" / "discovery.json"
+    with fixture_path.open(encoding="utf-8") as file:
+        return cast(_FixtureDiscoveryData, json.load(file))
+
 
 class _FixtureDiscoveryAdapter:
     """Return deterministic client envelopes without authentication or HTTP."""
@@ -16,9 +44,12 @@ class _FixtureDiscoveryAdapter:
     def __init__(self, device_name: str) -> None:
         """Initialize the adapter for a selected fixture device."""
         self._device_name = device_name
-        fixture_path = Path(__file__).parent / "fixtures" / "discovery.json"
-        with fixture_path.open(encoding="utf-8") as file:
-            self._discovery_data = cast(dict[str, dict[str, Any]], json.load(file))
+        self._discovery_data = _load_fixture_discovery_data()
+        self._device_metadata = next(
+            metadata
+            for metadata in self._discovery_data["devices"]
+            if metadata["fixtureName"] == device_name
+        )
         self._feature_data: dict[str, Any] | None = None
 
     async def get_installations(self) -> dict[str, Any]:
@@ -46,8 +77,8 @@ class _FixtureDiscoveryAdapter:
             "data": [
                 {
                     "id": "0",
-                    "modelId": self._device_name,
-                    "deviceType": DEVICE_TYPE_MAP.get(self._device_name, "heating"),
+                    "modelId": self._device_metadata["modelId"],
+                    "deviceType": self._device_metadata["deviceType"],
                     "status": "connected",
                 }
             ]
@@ -83,28 +114,14 @@ class _FixtureCommandAdapter:
         self, control: FeatureControl, parameters: dict[str, Any]
     ) -> dict[str, Any]:
         """Return a successful fixture command response."""
-        print(
-            f"[MOCK] Executing command '{control.command_name}' for feature "
-            f"'{control.parent_feature_name}' (param: {control.param_name}) "
-            f"with params: {parameters}"
+        _LOGGER.debug(
+            "Executing fixture command %r for feature %r (param: %s) with params: %s",
+            control.command_name,
+            control.parent_feature_name,
+            control.param_name,
+            parameters,
         )
         return {"data": {"success": True, "reason": "Mock Execution Success"}}
-
-
-# Mapping of fixture names to device types
-# This provides consistent device_type values for mock devices
-DEVICE_TYPE_MAP: dict[str, str] = {
-    "Vitocal151A": "heating",
-    "Vitocal200": "heating",
-    "Vitocal250A": "heating",
-    "Vitocal252": "heating",
-    "Vitocal300G": "heating",
-    "Vitodens050W": "heating",
-    "Vitodens200W": "heating",
-    "Vitodens300W": "heating",
-    "VitolaUniferral": "heating",
-    "Vitopure350": "ventilation",
-}
 
 
 class MockViClient(ViClient):
@@ -129,13 +146,10 @@ class MockViClient(ViClient):
 
     @staticmethod
     def get_available_mock_devices() -> list[str]:
-        """Return a list of available mock device names."""
-        fixtures_dir = Path(__file__).parent / "fixtures"
-        if not fixtures_dir.exists():
-            return []
+        """Return fixture names accepted by the fixture-backed client.
 
-        return sorted(
-            file.stem
-            for file in fixtures_dir.glob("*.json")
-            if file.stem != "discovery"
-        )
+        Returns:
+            Sorted fixture names from the bundled metadata catalog.
+        """
+        discovery_data = _load_fixture_discovery_data()
+        return sorted(metadata["fixtureName"] for metadata in discovery_data["devices"])

--- a/tests/test_mock_client.py
+++ b/tests/test_mock_client.py
@@ -1,5 +1,7 @@
 """Public workflow tests for the fixture-backed client."""
 
+import logging
+
 import pytest
 
 from vi_api_client import MockViClient
@@ -30,6 +32,52 @@ async def test_mock_device_hydration_uses_deterministic_fixture_topology():
     assert devices[0].id == "0"
     assert devices[0].model_id == "Vitodens200W"
     assert devices[0].features
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fixture_name", "model_id", "device_type"),
+    [
+        ("Vitocal200S", "Vitocal200S", "heating"),
+        ("Vitocal222S", "Vitocal222S", "heating"),
+        ("Vitocal250A", "Vitocal250A", "heating"),
+        (
+            "Vitocal333G-with-Vitovent300F",
+            "Vitocal333G-with-Vitovent300F",
+            "heating",
+        ),
+        ("Vitocharge03", "Vitocharge03", "battery"),
+        ("Vitodens200W", "Vitodens200W", "heating"),
+        ("Vitopure350", "Vitopure350", "ventilation"),
+    ],
+)
+async def test_mock_discovery_uses_each_fixture_metadata_definition(
+    fixture_name, model_id, device_type
+):
+    """Fixture discovery should expose each catalogued model and device type."""
+    # Arrange: Select one bundled fixture from the public fixture catalog.
+    client = MockViClient(fixture_name)
+
+    # Act: Discover the fixture through the public client workflow.
+    devices = await client.get_devices("99999", "MOCK_GATEWAY_SERIAL")
+
+    # Assert: The device identity comes from the fixture metadata definition.
+    assert [(device.model_id, device.device_type) for device in devices] == [
+        (model_id, device_type)
+    ]
+
+
+def test_mock_device_catalog_lists_each_fixture_metadata_definition():
+    """Fixture enumeration should use the same catalog as fixture discovery."""
+    assert MockViClient.get_available_mock_devices() == [
+        "Vitocal200S",
+        "Vitocal222S",
+        "Vitocal250A",
+        "Vitocal333G-with-Vitovent300F",
+        "Vitocharge03",
+        "Vitodens200W",
+        "Vitopure350",
+    ]
 
 
 @pytest.mark.asyncio
@@ -102,9 +150,10 @@ async def test_mock_client_rejects_malformed_fixture_feature_envelopes():
 
 
 @pytest.mark.asyncio
-async def test_mock_execute_command_is_offline_and_stateless():
+async def test_mock_execute_command_is_offline_and_stateless(capsys, caplog):
     """Mock command execution should not alter the loaded fixture features."""
     # Arrange: Load a writable fixture feature through the public workflow.
+    caplog.set_level(logging.DEBUG, logger="vi_api_client.mock_client")
     client = MockViClient("Vitocal250A")
     device = (await client.get_devices("99999", "MOCK_GATEWAY_SERIAL"))[0]
     device = await client.update_device(device)
@@ -118,3 +167,5 @@ async def test_mock_execute_command_is_offline_and_stateless():
     assert response.success
     assert response.reason == "Mock Execution Success"
     assert feature.value == 0.6
+    assert capsys.readouterr().out == ""
+    assert "Executing fixture command 'setCurve'" in caplog.text

--- a/tests/test_mock_data_integrity.py
+++ b/tests/test_mock_data_integrity.py
@@ -7,6 +7,7 @@ and delivered to users) is valid and can be correctly parsed by the library.
 import glob
 import json
 import os
+from pathlib import Path
 
 import pytest
 
@@ -25,6 +26,28 @@ def get_mock_data_files():
         file_path
         for file_path in glob.glob(os.path.join(MOCK_DATA_DIR, "*.json"))
         if not file_path.endswith("discovery.json")
+    )
+
+
+def test_mock_discovery_metadata_matches_bundled_device_fixtures():
+    """Each bundled device fixture should have exactly one metadata definition."""
+    # Arrange: Read the catalog that drives fixture enumeration and discovery.
+    discovery_path = Path(MOCK_DATA_DIR) / "discovery.json"
+    discovery_data = json.loads(discovery_path.read_text(encoding="utf-8"))
+    device_metadata = discovery_data["devices"]
+
+    # Act: Compare catalog fixture names with bundled feature-response filenames.
+    catalogued_fixture_names = {device["fixtureName"] for device in device_metadata}
+    bundled_fixture_names = {
+        Path(file_path).stem for file_path in get_mock_data_files()
+    }
+
+    # Assert: Metadata is complete, unique, and has the discovery identity fields.
+    assert catalogued_fixture_names == bundled_fixture_names
+    assert len(device_metadata) == len(catalogued_fixture_names)
+    assert all(
+        isinstance(device["modelId"], str) and isinstance(device["deviceType"], str)
+        for device in device_metadata
     )
 
 


### PR DESCRIPTION
## Summary
- make the discovery fixture catalog the authoritative source for fixture names, model IDs, and device types
- use that catalog for mock device enumeration and fixture-backed discovery
- replace fixture command stdout diagnostics with debug logging

## Validation
- ruff format --check .
- ruff check .
- pyright --pythonpath /Users/michael/Projekte/vi_api_client/.venv/bin/python
- python -m pytest -q
- python -m build

Closes #83